### PR TITLE
Chore/1565 automate release #7

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,10 +3,6 @@ name: Create TAG
 # Triggered manually or after Update completion
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Update"]
-    type:
-      - complete
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,6 +1,6 @@
 name: Create TAG
 
-# Triggered manually or after Update completion
+# Triggered manually or from Update
 on:
   workflow_dispatch:
 
@@ -13,9 +13,6 @@ jobs:
     name: Create TAG
     runs-on: ubuntu-latest
 
-    # Only if Update was sucessful
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,9 +20,6 @@ jobs:
       - name: Set new React Native version as ENV
         run: |
           echo "rn_version=test$(sh .github/scripts/extract_version.sh)" >> $GITHUB_ENV
-
-      - name: Print React Native Version from ENV
-        run: |
           echo "React Native version is: ${{ env.rn_version }}"
 
       - name: Create tag

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -60,3 +60,10 @@ jobs:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           message: "Update Native SDKs and increment ${{ github.event.inputs.increment }} version"
+
+      - name: Trigger Tag
+        run: |
+          curl --request POST \
+              --url 'https://api.github.com/repos/didomi/react-native/actions/workflows/tag.yml/dispatches' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --data '{ "ref": "${{ github.ref }}" }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -66,4 +66,4 @@ jobs:
           curl --request POST \
               --url 'https://api.github.com/repos/didomi/react-native/actions/workflows/tag.yml/dispatches' \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-              --data '{ "ref": "${{ github.ref }}" }
+              --data '{ "ref": "${{ github.ref }}" }''

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -66,4 +66,4 @@ jobs:
           curl --request POST \
               --url 'https://api.github.com/repos/didomi/react-native/actions/workflows/tag.yml/dispatches' \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-              --data '{ "ref": "${{ github.ref }}" }''
+              --data '{ "ref": "${{ github.ref }}" }'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.3):
+  - react-native-didomi (1.3.4):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 157e69fbb1a9e61718dd393457d59ee18190ae1b
+  react-native-didomi: bcbddb757a361f2e0c3d245a303720f1c1dda9cd
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.4):
+  - react-native-didomi (1.3.5):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: bcbddb757a361f2e0c3d245a303720f1c1dda9cd
+  react-native-didomi: 2a7df558955305590832f3f5b833c627844c7614
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.5):
+  - react-native-didomi (1.3.6):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 2a7df558955305590832f3f5b833c627844c7614
+  react-native-didomi: 1b21bad68b5e1b2be704fb07fd5761a58bd3c69a
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.2):
+  - react-native-didomi (1.3.3):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 80975378219f4669da1da99dfe6ff5645225aebe
+  react-native-didomi: 157e69fbb1a9e61718dd393457d59ee18190ae1b
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.1):
+  - react-native-didomi (1.3.2):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 70a629e0e1fbfc97605eeb9a80739f414c3e9654
+  react-native-didomi: 80975378219f4669da1da99dfe6ff5645225aebe
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/sampleApp/ios/Podfile.lock
+++ b/sampleApp/ios/Podfile.lock
@@ -274,7 +274,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.6):
+  - react-native-didomi (1.4.0):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -470,7 +470,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 1b21bad68b5e1b2be704fb07fd5761a58bd3c69a
+  react-native-didomi: b439ee96f3960660930559fa6db5a7fe9e73cd15
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.6"
+export const DIDOMI_VERSION = "1.4.0"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.1"
+export const DIDOMI_VERSION = "1.3.2"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.4"
+export const DIDOMI_VERSION = "1.3.5"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.5"
+export const DIDOMI_VERSION = "1.3.6"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.2"
+export const DIDOMI_VERSION = "1.3.3"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
 // User agent name
 export const DIDOMI_USER_AGENT_NAME = "Didomi React-Native SDK"
 // User agent version
-export const DIDOMI_VERSION = "1.3.3"
+export const DIDOMI_VERSION = "1.3.4"

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.5):
+  - react-native-didomi (1.3.6):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 2a7df558955305590832f3f5b833c627844c7614
+  react-native-didomi: 1b21bad68b5e1b2be704fb07fd5761a58bd3c69a
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.2):
+  - react-native-didomi (1.3.3):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 80975378219f4669da1da99dfe6ff5645225aebe
+  react-native-didomi: 157e69fbb1a9e61718dd393457d59ee18190ae1b
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.6):
+  - react-native-didomi (1.4.0):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 1b21bad68b5e1b2be704fb07fd5761a58bd3c69a
+  react-native-didomi: b439ee96f3960660930559fa6db5a7fe9e73cd15
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.4):
+  - react-native-didomi (1.3.5):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: bcbddb757a361f2e0c3d245a303720f1c1dda9cd
+  react-native-didomi: 2a7df558955305590832f3f5b833c627844c7614
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.3):
+  - react-native-didomi (1.3.4):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 157e69fbb1a9e61718dd393457d59ee18190ae1b
+  react-native-didomi: bcbddb757a361f2e0c3d245a303720f1c1dda9cd
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/testApp/ios/Podfile.lock
+++ b/testApp/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-didomi (1.3.1):
+  - react-native-didomi (1.3.2):
     - Didomi-XCFramework (= 1.64.0)
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-didomi: 70a629e0e1fbfc97605eeb9a80739f414c3e9654
+  react-native-didomi: 80975378219f4669da1da99dfe6ff5645225aebe
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0


### PR DESCRIPTION
Relates to CMP-1565

The `Update` workflow will trigger the `Create Tag` workflow from a step (instead of `workflow_run`). 
revert bridge version 1.4.0