### PR TITLE
move firebase dependency to testApp

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,8 +151,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "@react-native-firebase/app": "^12.0.0"
   }
 }

--- a/testApp/package.json
+++ b/testApp/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.63.4"
+    "react-native": "0.63.4",
+    "@react-native-firebase/app": "^12.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
Closes: CMP-2701
Relates to: https://github.com/didomi/react-native/issues/38

Move firebase dependency to testApp.
This dependency is required only for UI tests from Firebase (CI).