### PR TITLE
Refactor/2126 gcloud auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,13 @@ jobs:
         name: app-debug-androidTest.apk 
         path: testApp/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 
-    - id: Authenticate Cloud SDK
+    # Authenticate Cloud SDK
+    - id: 'auth'
       uses: 'google-github-actions/auth@v0'
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-    - name: Set up Cloud SDK
+    - name: Setup Cloud SDK
       uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -47,7 +47,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node
       uses: actions/setup-node@v2
@@ -126,7 +126,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node
       uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,15 @@ jobs:
         name: app-debug-androidTest.apk 
         path: testApp/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 
+    - id: Authenticate Cloud SDK
+      uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
-        export_default_credentials: true
 
     - name: Run Instrumentation Tests in Firebase Test Lab
       run: |


### PR DESCRIPTION
Closes: CMP-2126

Update CI scripts:
- use checkout v3
- use `google-github-actions/auth` for GCLOUD auth