### PR TITLE
Fix onReady / onError callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,13 @@ jobs:
       run: yarn install
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/sampleApp/src/App.tsx
+++ b/sampleApp/src/App.tsx
@@ -58,8 +58,8 @@ function App() {
       console.log('ready');
     });
 
-    Didomi.onError().then((err: any) => {
-      console.log('error: ' + err);
+    Didomi.onError().then(() => {
+      console.log('error');
     });
 
     /*Didomi.addEventListener(DidomiEventType.READY, (data: any) => {

--- a/sampleApp/src/Methods.tsx
+++ b/sampleApp/src/Methods.tsx
@@ -21,7 +21,10 @@ export default function Methods() {
       <MethodCall
         name="initialize"
         call={() => {
-          Didomi.initialize(apiKey);
+          Didomi.initialize(apiKey).catch((err) => {
+            console.log(err);
+            return false
+          });
         }}
         test={() => {
           return true;

--- a/src/Didomi.ts
+++ b/src/Didomi.ts
@@ -53,16 +53,18 @@ export const Didomi = {
    * Listen to SDK ready state
    */
   onReady: (): Promise<void> => {
-    DidomiListener.setOnReadyListener();
-    return RNDidomi.onReady();
+    var promise = DidomiListener.setOnReadyListener();
+    RNDidomi.onReady();
+    return promise;
   },
 
   /**
    * Listen to SDK errors
    */
   onError: (): Promise<void> => {
-    DidomiListener.setOnErrorListener();
-    return RNDidomi.onError();
+    var promise = DidomiListener.setOnErrorListener();
+    RNDidomi.onError();
+    return promise;
   },
 
   /**

--- a/testApp/src/App.tsx
+++ b/testApp/src/App.tsx
@@ -43,9 +43,7 @@ function App() {
     registerListener(DidomiEventType.PREFERENCES_CLICK_CATEGORY_AGREE);
     registerListener(DidomiEventType.PREFERENCES_CLICK_CATEGORY_DISAGREE);
     registerListener(DidomiEventType.PREFERENCES_CLICK_DISAGREE_TO_ALL);
-    registerListener(
-      DidomiEventType.PREFERENCES_CLICK_DISAGREE_TO_ALL_PURPOSES
-    );
+    registerListener(DidomiEventType.PREFERENCES_CLICK_DISAGREE_TO_ALL_PURPOSES);
     registerListener(DidomiEventType.PREFERENCES_CLICK_DISAGREE_TO_ALL_VENDORS);
     registerListener(DidomiEventType.PREFERENCES_CLICK_PURPOSE_AGREE);
     registerListener(DidomiEventType.PREFERENCES_CLICK_PURPOSE_DISAGREE);


### PR DESCRIPTION
Fix onReady / onError callbacks
prevent `Possible Unhandled Promise Rejection (id: 0`) for sample init (wrong API key length)
Update actions/cache to v3 (missed in the previous PR)