### PR TITLE
CMP-3554 test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,10 @@
-name: ci
+name: Test
 
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - '**'
+      - "!main" # Prevent when pushing on main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   push:
     branches:
+      - "**"
       - "!main" # Prevent when pushing on main
   workflow_dispatch:
 


### PR DESCRIPTION
- Rename test workflow (`ci` -> `test`)
- Trigger test workflow on push excluding `main` branch