### PR TITLE
Export missing types from Didomi plugin

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,2 @@
 export { Didomi } from './Didomi';
-export { DidomiEventType } from './DidomiTypes';
+export { DidomiEventType, Vendor, VendorNamespaces, Purpose, PurposeCategory, UserStatus, UserStatusPurposes, UserStatusVendors, UserStatusIds } from './DidomiTypes';

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
@@ -50,7 +50,7 @@ class UIGettersParamsTest: BaseUITest() {
         // Android doesn't always keep the same order for the properties.
         assertTextContains("\"specialPurposeIds\":[\"1\",\"2\"]")
         assertTextContains("\"featureIds\":[\"1\",\"2\"]")
-        assertTextContains("\"policyUrl\":\"https://policies.google.com/privacy\"")
+        assertTextContains("\"policyUrl\":\"https://business.safety.google/privacy/\"")
         assertTextContains("\"deviceStorageDisclosureUrl\":\"https://www.gstatic.com/iabtcf/deviceStorageDisclosure.json\"")
         assertTextContains("\"name\":\"Google Advertising Products\"")
         assertTextContains("\"id\":\"google\"")
@@ -66,7 +66,7 @@ class UIGettersParamsTest: BaseUITest() {
 
         tapButton("getVendor [ID = '755'] policyUrl")
 
-        assertText("\"https://policies.google.com/privacy\"")
+        assertText("\"https://business.safety.google/privacy/\"")
     }
 
     @Test


### PR DESCRIPTION
Export some types missing from Didomi plugin:
- `Vendor`
- `VendorNamespaces`
- `Purpose`
- `PurposeCategory`
- `UserStatus`
- `UserStatusPurposes`
- `UserStatusVendors`
- `UserStatusIds`