### PR TITLE
CMP-4037 update android api 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,5 +124,5 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    implementation "io.didomi.sdk:android:1.82.0"
+    implementation "io.didomi.sdk:android:1.83.1"
 }

--- a/sampleApp/android/build.gradle
+++ b/sampleApp/android/build.gradle
@@ -5,10 +5,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext.kotlin_version = "1.7.20"
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"

--- a/testApp/android/build.gradle
+++ b/testApp/android/build.gradle
@@ -5,10 +5,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext.kotlin_version = "1.7.20"
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"


### PR DESCRIPTION
- use Android API 33 for sample and tests apps
- use latest native android SDK (1.83.1)