### PR TITLE
Update vendors and purposes structure for TCF 2.2, update tests

### DIFF
--- a/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
+++ b/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
@@ -284,7 +284,16 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         obj?.serializeToMap()?.entries?.forEach { entry ->
             when (val value = entry.value) {
                 is Map<*, *> -> map.putMap(entry.key, objectToWritableMap(value))
-                is List<*> -> map.putArray(entry.key, Arguments.fromList(value))
+                is List<*> -> {
+                    var isString = false
+                    val listValues = value.map {
+                        if (it is String) {
+                            isString = true
+                            it
+                        } else objectToWritableMap(it)
+                    }
+                    map.putArray(entry.key, if (isString) Arguments.fromList(listValues) else Arguments.makeNativeArray(listValues))
+                }
                 else -> map.putString(entry.key, value.toString())
             }
         }

--- a/src/DidomiTypes.ts
+++ b/src/DidomiTypes.ts
@@ -57,6 +57,7 @@ export interface Vendor {
   iabId: string
   name: string;
   policyUrl: string;
+  urls: VendorUrls[];
   namespace: string;
   namespaces: VendorNamespaces;
   iabVendor: boolean;
@@ -65,12 +66,26 @@ export interface Vendor {
   specialPurposeIds: string[];
   legIntPurposeIds: string[];
   specialFeatureIds: string[];
-  cookieMaxAgeSeconds: number
+  dataDeclaration: string[];
+  dataRetention: VendorDataRetention;
+  cookieMaxAgeSeconds: number;
   usesNonCookieAccess: boolean;
 }
 
 export interface VendorNamespaces {
   iab2: string;
+}
+
+export interface VendorUrls {
+  privacy: string;
+  legIntClaim: string;
+  langId: string;
+}
+
+export interface VendorDataRetention {
+  stdRetention: number;
+  purposes: Map<number>;
+  specialPurposes: Map<number>;
 }
 
 export interface Purpose {
@@ -79,6 +94,7 @@ export interface Purpose {
   name: string;
   description: string;
   descriptionLegal: string;
+  illustrations: string[];
   custom: boolean;
   essential: boolean;
   specialFeature: boolean;

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/BaseUITest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/BaseUITest.kt
@@ -71,7 +71,9 @@ open class BaseUITest {
     companion object {
         // Considering the tests that we do for the bridge SDKs, using simple a configuration with few vendors
         // should be enough. Currently we share the same vendor and purpose configuration across tests classes.
-        const val ALL_VENDOR_IDS = "28,google"
-        const val ALL_PURPOSE_IDS = "cookies,create_ads_profile,geolocation_data,select_personalized_ads"
+        const val ALL_VENDOR_IDS = "1111,217,272"
+        const val ALL_PURPOSE_IDS = "cookies,create_ads_profile,device_characteristics,geolocation_data," +
+                "improve_products,market_research,measure_ad_performance,measure_content_performance," +
+                "select_basic_ads,select_personalized_ads,use_limited_data_to_select_content"
     }
 }

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
@@ -37,15 +37,15 @@ class UIGettersParamsTest: BaseUITest() {
     @Test
     fun test_GetPurpose_descriptionLegal() {
 
-        tapButton("getPurpose [ID = 'cookies'] descriptionLegal")
+        tapButton("getPurpose [ID = 'cookies'] illustrations[0]")
 
-        assertText("\"Vendors can:\\n* Store and access information on the device such as cookies and device identifiers presented to a user.\"")
+        assertText("Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).")
     }
 
     @Test
     fun test_GetVendor() {
 
-        tapButton("getVendor [ID = '755']")
+        tapButton("getVendor [ID = '217']")
 
         // Android doesn't always keep the same order for the properties.
         assertTextContains("\"specialPurposeIds\":[\"1\",\"2\"]")
@@ -64,7 +64,7 @@ class UIGettersParamsTest: BaseUITest() {
     @Test
     fun test_GetPurpose_policyUrl() {
 
-        tapButton("getVendor [ID = '755'] policyUrl")
+        tapButton("getVendor [ID = '217'] policyUrl")
 
         assertText("\"https://business.safety.google/privacy/\"")
     }
@@ -93,7 +93,7 @@ class UIGettersParamsTest: BaseUITest() {
     fun test_GetUserConsentStatusForVendor() {
         agreeToAll()
 
-        tapButton("getUserConsentStatusForVendor [ID = '755']")
+        tapButton("getUserConsentStatusForVendor [ID = '217']")
         assertText("true")
     }
 
@@ -101,7 +101,7 @@ class UIGettersParamsTest: BaseUITest() {
     fun test_GetUserConsentStatusForVendorAndRequiredPurposes() {
         agreeToAll()
 
-        tapButton("getUserConsentStatusForVendorAndRequiredPurposes [ID = '755']")
+        tapButton("getUserConsentStatusForVendorAndRequiredPurposes [ID = '217']")
         assertText("true")
     }
 

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersParamsTest.kt
@@ -27,19 +27,19 @@ class UIGettersParamsTest: BaseUITest() {
         tapButton("getPurpose [ID = 'cookies']")
 
         // Android doesn't always keep the same order for the properties.
-        assertTextContains("\"iabId\":\"1\"")
-        assertTextContains("\"description\":\"Cookies, device identifiers, or other information can be stored or accessed on your device for the purposes presented to you.\"")
-        assertTextContains("\"name\":\"Store and/or access information on a device\"")
         assertTextContains("\"id\":\"cookies\"")
-        assertTextContains("\"descriptionLegal\":\"Vendors can:\\n* Store and access information on the device such as cookies and device identifiers presented to a user.\"")
+        assertTextContains("\"iabId\":\"1\"")
+        assertTextContains("\"name\":\"Store and/or access information on a device\"")
+        assertTextContains("\"description\":\"Cookies, device or similar online identifiers (e.g. login-based identifiers, randomly assigned identifiers, network based identifiers) together with other information (e.g. browser type and information, language, screen size, supported technologies etc.) can be stored or read on your device to recognise it each time it connects to an app or to a website, for one or several of the purposes presented here.\"")
+        assertTextContains("\"illustrations\":[\"Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).\"]")
     }
 
     @Test
-    fun test_GetPurpose_descriptionLegal() {
+    fun test_GetPurpose_illustrations() {
 
         tapButton("getPurpose [ID = 'cookies'] illustrations[0]")
 
-        assertText("Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).")
+        assertText("\"Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).\"")
     }
 
     @Test
@@ -48,25 +48,23 @@ class UIGettersParamsTest: BaseUITest() {
         tapButton("getVendor [ID = '217']")
 
         // Android doesn't always keep the same order for the properties.
+        assertTextContains("\"id\":\"217\"")
+        assertTextContains("\"name\":\"2KDirect, Inc. (dba iPromote)\"")
+        assertTextContains("\"purposeIds\":[\"cookies\",\"create_ads_profile\",\"select_personalized_ads\"")
         assertTextContains("\"specialPurposeIds\":[\"1\",\"2\"]")
-        assertTextContains("\"featureIds\":[\"1\",\"2\"]")
-        assertTextContains("\"policyUrl\":\"https://business.safety.google/privacy/\"")
-        assertTextContains("\"deviceStorageDisclosureUrl\":\"https://sdk.privacy-center.org/tcf/v2/disclosures/755.json\"")
-        assertTextContains("\"name\":\"Google Advertising Products\"")
-        assertTextContains("\"id\":\"google\"")
-        assertTextContains("\"iabId\":\"755\"")
-        assertTextContains("\"namespace\":\"didomi\"")
-        assertTextContains("\"namespaces\":{\"iab2\":\"755\"}")
-        assertTextContains("\"usesNonCookieAccess\":\"true\"")
-        assertTextContains("\"purposeIds\":[\"cookies\",\"create_ads_profile\",")
+        assertTextContains("\"deviceStorageDisclosureUrl\":\"https://sdk.privacy-center.org/tcf/v3/disclosures/217.json\"")
+        assertTextContains("\"namespace\":\"iab\"")
+        assertTextContains("\"usesNonCookieAccess\":\"false\"")
     }
 
     @Test
-    fun test_GetPurpose_policyUrl() {
+    fun test_GetPurpose_urls() {
 
-        tapButton("getVendor [ID = '217'] policyUrl")
+        tapButton("getVendor [ID = '217'] urls[0]")
 
-        assertText("\"https://business.safety.google/privacy/\"")
+        assertTextContains("\"langId\":\"en\"")
+        assertTextContains("\"privacy\":\"https://www.ipromote.com/privacy-policy/\"")
+        assertTextContains("\"legIntClaim\":\"https://www.ipromote.com/privacy-policy/\"")
     }
 
     @Test

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIGettersTest.kt
@@ -118,7 +118,7 @@ class UIGettersTest: BaseUITest() {
         // The text might change every time we call the getUserStatus method
         // so we'll only assert the first level parameters of the resulting json string.
         assertTextContains("\"addtl_consent\":\"\"".trim())
-        assertTextContains("\"consent_string\":\"\"".trim())
+        assertTextContains("\"consent_string\":\"".trim())
         assertTextContains("\"purposes\":{\"legitimate_interest\":{\"enabled\":[".trim())
         assertTextContains("\"vendors\":{\"legitimate_interest\":{\"enabled\":[".trim())
         assertTextContains("\"user_id\":\"".trim())

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIMethodsTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UIMethodsTest.kt
@@ -23,6 +23,7 @@ class UIMethodsTest: BaseUITest() {
     @Before
     fun init() {
         waitForSdkToBeReady()
+        testMethodCall("reset")
     }
 
     private fun testMethodCall(method: String) {
@@ -42,11 +43,6 @@ class UIMethodsTest: BaseUITest() {
 
     fun test_SDKInitOK() {
         testLastEvent("on_ready")
-    }
-
-    @Test
-    fun test_Reset() {
-        testMethodCall("reset")
     }
 
     @Test

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -9,8 +9,8 @@ import XCTest
 
 class DidomiExampleUITests: XCTestCase {
     
-  let allPurposeIDs = "cookies,create_ads_profile,geolocation_data,select_personalized_ads"
-  let allVendorIDs = "28,google"
+  let allPurposeIDs = "cookies,create_ads_profile,device_characteristics,geolocation_data,improve_products,market_research,measure_ad_performance,measure_content_performance,select_basic_ads,select_personalized_ads,use_limited_data_to_select_content"
+  let allVendorIDs = "1111,217,272"
   
   override func setUpWithError() throws {
     // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -38,7 +38,7 @@ class DidomiExampleUITests: XCTestCase {
     waitForExpectations(timeout: 5, handler: nil)
   }
   
-  func testAOnReadyEvent() throws {
+  func testOnReadyEvent() throws {
     
     // Restart the app to make sure last event is "on ready"
     let app = XCUIApplication()
@@ -335,15 +335,15 @@ class DidomiExampleUITests: XCTestCase {
     let actualRaw = staticText.label.removeNewLinesAndTrailingSpaces()
     let actual = decodePurpose(actualRaw)
     
-    let expected = PurposeData(id: "cookies", name: "Store and/or access information on a device", iabId: "1", description: "Cookies, device identifiers, or other information can be stored or accessed on your device for the purposes presented to you.")
+    let expected = PurposeData(id: "cookies", name: "Store and/or access information on a device", iabId: "1", description: "Cookies, device or similar online identifiers (e.g. login-based identifiers, randomly assigned identifiers, network based identifiers) together with other information (e.g. browser type and information, language, screen size, supported technologies etc.) can be stored or read on your device to recognise it each time it connects to an app or to a website, for one or several of the purposes presented here.")
     assertEqual(actual, expected)
   }
   
-  func testGetPurposeWithId_descriptionLegal() throws {
+  func testGetPurposeWithId_illustrations() throws {
     let app = XCUIApplication()
         
     tapButton(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]")
-    assertResult(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]", expected: "Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).")
+    assertResult(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]", expected: "\"Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).\"")
   }
   
   func testGetVendorWithId() throws {
@@ -357,15 +357,23 @@ class DidomiExampleUITests: XCTestCase {
     let actualRaw = staticText.label.removeNewLinesAndTrailingSpaces()
     let actual = decodeVendor(actualRaw)
     
-    let expected = VendorData(id: "google", name: "Google Advertising Products", iabId: "755", namespace: "didomi", policyUrl: "https://policies.google.com/privacy")
+    let expected = VendorData(id: "217", name: "2KDirect, Inc. (dba iPromote)", iabId: "", namespace: "iab", policyUrl: nil)
     assertEqual(actual, expected)
   }
   
-  func testGetVendorWithId_policyUrl() throws {
+  func testGetVendorWithId_urls() throws {
     let app = XCUIApplication()
         
-    tapButton(in: app, name: "getVendor [ID = '217'] policyUrl")
-    assertResult(in: app, name: "getVendor [ID = '217'] policyUrl", expected: "\"https://policies.google.com/privacy\"")
+    tapButton(in: app, name: "getVendor [ID = '217'] urls[0]")
+
+    let staticText = app.staticTexts["getVendor [ID = '217'] urls[0]-result"]
+    staticText.wait()
+    
+    let actualRaw = staticText.label.removeNewLinesAndTrailingSpaces()
+    let actual = decodeVendorURLData(actualRaw)
+
+    let expected = VendorURLData(langId: "en", privacy: "https://www.ipromote.com/privacy-policy/", legIntClaim: "https://www.ipromote.com/privacy-policy/")
+    assertEqual(actual, expected)
   }
   
   func testGetText() throws {
@@ -432,8 +440,8 @@ class DidomiExampleUITests: XCTestCase {
     
     resetUserStatus(in: app)
     
-    tapButton(in: app, name: "getUserLegitimateInterestStatusForVendor [ID = '755']")
-    assertResult(in: app, name: "getUserLegitimateInterestStatusForVendor [ID = '755']", expected: "true")
+    tapButton(in: app, name: "getUserLegitimateInterestStatusForVendor [ID = '217']")
+    assertResult(in: app, name: "getUserLegitimateInterestStatusForVendor [ID = '217']", expected: "true")
   }
   
   func testGetJavaScriptForWebViewWithExtra() throws {
@@ -464,8 +472,8 @@ class DidomiExampleUITests: XCTestCase {
     
     resetUserStatus(in: app)
     
-    tapButton(in: app, name: "getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '755']")
-    assertResult(in: app, name: "getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '755']", expected: "true")
+    tapButton(in: app, name: "getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '217']")
+    assertResult(in: app, name: "getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '217']", expected: "true")
   }
   
   // MARK: SETTERS
@@ -622,11 +630,24 @@ extension DidomiExampleUITests {
     return try! jsonDecoder.decode(VendorData.self, from: data!)
   }
   
+  func decodeVendorURLData(_ string: String) -> VendorURLData {
+    let data = string.data(using: .utf8)
+    let jsonDecoder = JSONDecoder()
+    return try! jsonDecoder.decode(VendorURLData.self, from: data!)
+  }
+  
+
   func assertEqual(_ vendor1: VendorData, _ vendor2: VendorData) {
     XCTAssertEqual(vendor1.name, vendor2.name)
     XCTAssertEqual(vendor1.id, vendor2.id)
     XCTAssertEqual(vendor1.iabId, vendor2.iabId)
     XCTAssertEqual(vendor1.namespace, vendor2.namespace)
     XCTAssertEqual(vendor1.policyUrl, vendor2.policyUrl)
+  }
+
+  func assertEqual(_ url1: VendorURLData, _ url2: VendorURLData) {
+    XCTAssertEqual(url1.langId, url2.langId)
+    XCTAssertEqual(url1.privacy, url2.privacy)
+    XCTAssertEqual(url1.legIntClaim, url2.legIntClaim)
   }
 }

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -46,7 +46,6 @@ class DidomiExampleUITests: XCTestCase {
     app.activate()
     
     testLastEvent(app: app, name:"on_ready")
-    
   }
 
   func testSdkReady() throws {
@@ -64,6 +63,7 @@ class DidomiExampleUITests: XCTestCase {
   
   func testSetupUI() throws {
     let app = XCUIApplication()
+    tapButton(in: app, name: "reset")
     tapButton(in: app, name: "setupUI")
     assertResult(in: app, name: "setupUI", expected: "setupUI-OK")
     
@@ -98,6 +98,7 @@ class DidomiExampleUITests: XCTestCase {
   
   func testShowNotice() throws {
     let app = XCUIApplication()
+    tapButton(in: app, name: "reset")
     tapButton(in: app, name: "showNotice")
     assertResult(in: app, name: "showNotice", expected: "showNotice-OK")
     
@@ -257,7 +258,7 @@ class DidomiExampleUITests: XCTestCase {
     // The text might change every time we call the getUserStatus method
     // so we'll only assert the first level parameters of the resulting json string.
     XCTAssertTrue(actual.contains("\"addtl_consent\":\"\""))
-    XCTAssertTrue(actual.contains("\"consent_string\":\"\""))
+    XCTAssertTrue(actual.contains("\"consent_string\":\""))
     XCTAssertTrue(actual.contains("\"purposes\":{\"legitimate_interest\":{\"enabled\":["))
     XCTAssertTrue(actual.contains("\"vendors\":{\"consent\":{\"enabled\":["))
     XCTAssertTrue(actual.contains("\"user_id\":\""))

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -342,16 +342,16 @@ class DidomiExampleUITests: XCTestCase {
   func testGetPurposeWithId_descriptionLegal() throws {
     let app = XCUIApplication()
         
-    tapButton(in: app, name: "getPurpose [ID = 'cookies'] descriptionLegal")
-    assertResult(in: app, name: "getPurpose [ID = 'cookies'] descriptionLegal", expected: "\"Vendors can:\\n* Store and access information on the device such as cookies and device identifiers presented to a user.\"")
+    tapButton(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]")
+    assertResult(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]", expected: "Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).")
   }
   
   func testGetVendorWithId() throws {
     let app = XCUIApplication()
         
-    tapButton(in: app, name: "getVendor [ID = '755']")
+    tapButton(in: app, name: "getVendor [ID = '217']")
     
-    let staticText = app.staticTexts["getVendor [ID = '755']-result"]
+    let staticText = app.staticTexts["getVendor [ID = '217']-result"]
     staticText.wait()
     
     let actualRaw = staticText.label.removeNewLinesAndTrailingSpaces()
@@ -364,8 +364,8 @@ class DidomiExampleUITests: XCTestCase {
   func testGetVendorWithId_policyUrl() throws {
     let app = XCUIApplication()
         
-    tapButton(in: app, name: "getVendor [ID = '755'] policyUrl")
-    assertResult(in: app, name: "getVendor [ID = '755'] policyUrl", expected: "\"https://policies.google.com/privacy\"")
+    tapButton(in: app, name: "getVendor [ID = '217'] policyUrl")
+    assertResult(in: app, name: "getVendor [ID = '217'] policyUrl", expected: "\"https://policies.google.com/privacy\"")
   }
   
   func testGetText() throws {
@@ -396,8 +396,8 @@ class DidomiExampleUITests: XCTestCase {
     
     agreeToAll(in: app)
     
-    tapButton(in: app, name: "getUserConsentStatusForVendor [ID = '755']")
-    assertResult(in: app, name: "getUserConsentStatusForVendor [ID = '755']", expected: "true")
+    tapButton(in: app, name: "getUserConsentStatusForVendor [ID = '217']")
+    assertResult(in: app, name: "getUserConsentStatusForVendor [ID = '217']", expected: "true")
   }
   
   func testGetUserStatusForVendor() throws {
@@ -405,8 +405,8 @@ class DidomiExampleUITests: XCTestCase {
     
     agreeToAll(in: app)
     
-    tapButton(in: app, name: "getUserStatusForVendor [ID = '755']")
-    assertResult(in: app, name: "getUserStatusForVendor [ID = '755']", expected: "true")
+    tapButton(in: app, name: "getUserStatusForVendor [ID = '217']")
+    assertResult(in: app, name: "getUserStatusForVendor [ID = '217']", expected: "true")
   }
   
   func testGetUserConsentStatusForVendorAndRequiredPurpose() throws {
@@ -414,8 +414,8 @@ class DidomiExampleUITests: XCTestCase {
     
     agreeToAll(in: app)
     
-    tapButton(in: app, name: "getUserConsentStatusForVendorAndRequiredPurposes [ID = '755']")
-    assertResult(in: app, name: "getUserConsentStatusForVendorAndRequiredPurposes [ID = '755']", expected: "true")
+    tapButton(in: app, name: "getUserConsentStatusForVendorAndRequiredPurposes [ID = '217']")
+    assertResult(in: app, name: "getUserConsentStatusForVendorAndRequiredPurposes [ID = '217']", expected: "true")
   }
   
   func testGetUserLegitimateInterestStatusForPurpose() throws {

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -23,8 +23,6 @@ class DidomiExampleUITests: XCTestCase {
   private func initApp() -> XCUIApplication {
     let app = XCUIApplication()
     app.activate()
-    
-    testLastEvent(app: app, name:"on_ready")
     return app
   }
   

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -20,6 +20,14 @@ class DidomiExampleUITests: XCTestCase {
     continueAfterFailure = false
   }
   
+  private func initApp() -> XCUIApplication {
+    let app = XCUIApplication()
+    app.activate()
+    
+    testLastEvent(app: app, name:"on_ready")
+    return app
+  }
+  
   private func waitUntilElementExists(element: XCUIElement, timeout: TimeInterval) {
     let startTime = Date.timeIntervalSinceReferenceDate
     while !element.exists {
@@ -39,9 +47,9 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testOnReadyEvent() throws {
+    let app = initApp()
     
     // Restart the app to make sure last event is "on ready"
-    let app = XCUIApplication()
     app.terminate()
     app.activate()
     
@@ -49,20 +57,20 @@ class DidomiExampleUITests: XCTestCase {
   }
 
   func testSdkReady() throws {
-    let app = XCUIApplication()
+    let app = initApp()
 
     assertResult(in: app, name: "ready", expected: "SDK STATUS: READY")
   }
   
   func testReset() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "reset")
     assertResult(in: app, name: "reset", expected: "reset-OK")
   }
   
   func testSetupUI() throws {
-    let app = XCUIApplication()
+    let app = initApp()
     tapButton(in: app, name: "reset")
     tapButton(in: app, name: "setupUI")
     assertResult(in: app, name: "setupUI", expected: "setupUI-OK")
@@ -81,15 +89,15 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testSetLogLevel() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setLogLevel")
     assertResult(in: app, name: "setLogLevel", expected: "setLogLevel-OK")
   }
   
   func testUpdateSelectedLanguage() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "updateSelectedLanguage")
     assertResult(in: app, name: "updateSelectedLanguage", expected: "updateSelectedLanguage-OK")
 
@@ -97,7 +105,7 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testShowNotice() throws {
-    let app = XCUIApplication()
+    let app = initApp()
     tapButton(in: app, name: "reset")
     tapButton(in: app, name: "showNotice")
     assertResult(in: app, name: "showNotice", expected: "showNotice-OK")
@@ -115,15 +123,15 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testHideNotice() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "hideNotice")
     assertResult(in: app, name: "hideNotice", expected: "hideNotice-OK")
   }
   
   func testHidePreferences() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "hidePreferences")
     assertResult(in: app, name: "hidePreferences", expected: "hidePreferences-OK")
   }
@@ -132,8 +140,8 @@ class DidomiExampleUITests: XCTestCase {
   // MARK: GETTERS
   
   func testGetDisabledPurposes() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     disagreeToAll(in: app)
     
     tapButton(in: app, name: "getDisabledPurposes")
@@ -141,8 +149,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetDisabledPurposeIds() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     disagreeToAll(in: app)
     
     tapButton(in: app, name: "getDisabledPurposeIds")
@@ -150,8 +158,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetDisabledVendors() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     disagreeToAll(in: app)
     
     tapButton(in: app, name: "getDisabledVendors")
@@ -159,8 +167,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetDisabledVendorIds() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     disagreeToAll(in: app)
     
     tapButton(in: app, name: "getDisabledVendorIds")
@@ -168,8 +176,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetEnabledPurposes() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getEnabledPurposes")
@@ -177,8 +185,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetEnabledPurposeIds() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getEnabledPurposeIds")
@@ -186,8 +194,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetEnabledVendors() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getEnabledVendors")
@@ -195,8 +203,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetEnabledVendorIds() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getEnabledVendorIds")
@@ -204,8 +212,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetJavaScriptForWebView() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     let expected = """
@@ -226,8 +234,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetQueryStringForWebView() throws {
-    let app = XCUIApplication()
-        
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     let expected = "\"didomiConfig.user.externalConsent.value".removeNewLinesAndTrailingSpaces()
@@ -246,8 +254,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserStatus() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "getUserStatus")
     
     let staticText = app.staticTexts["getUserStatus-result"]
@@ -270,8 +278,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserStatus_Purposes() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "getUserStatus purposes")
     
     let staticText = app.staticTexts["getUserStatus purposes-result"]
@@ -288,8 +296,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserStatus_Vendors() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "getUserStatus vendors")
     
     let staticText = app.staticTexts["getUserStatus vendors-result"]
@@ -307,8 +315,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserStatus_Vendors_global_consent() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "getUserStatus vendors global_consent")
     
     let staticText = app.staticTexts["getUserStatus vendors global_consent-result"]
@@ -326,8 +334,8 @@ class DidomiExampleUITests: XCTestCase {
   // MARK: GETTERS WITH PARAMS
   
   func testGetPurposeWithId() throws {
-    let app = XCUIApplication()
-        
+    let app = initApp()
+
     tapButton(in: app, name: "getPurpose [ID = 'cookies']")
     
     let staticText = app.staticTexts["getPurpose [ID = 'cookies']-result"]
@@ -341,15 +349,15 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetPurposeWithId_illustrations() throws {
-    let app = XCUIApplication()
-        
+    let app = initApp()
+
     tapButton(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]")
     assertResult(in: app, name: "getPurpose [ID = 'cookies'] illustrations[0]", expected: "\"Most purposes explained in this notice rely on the storage or accessing of information from your device when you use an app or visit a website. For example, a vendor or publisher might need to store a cookie on your device during your first visit on a website, to be able to recognise your device during your next visits (by accessing this cookie each time).\"")
   }
   
   func testGetVendorWithId() throws {
-    let app = XCUIApplication()
-        
+    let app = initApp()
+
     tapButton(in: app, name: "getVendor [ID = '217']")
     
     let staticText = app.staticTexts["getVendor [ID = '217']-result"]
@@ -363,8 +371,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetVendorWithId_urls() throws {
-    let app = XCUIApplication()
-        
+    let app = initApp()
+
     tapButton(in: app, name: "getVendor [ID = '217'] urls[0]")
 
     let staticText = app.staticTexts["getVendor [ID = '217'] urls[0]-result"]
@@ -378,8 +386,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetText() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "getText [Key = '0']")
     assertResult(in: app, name: "getText [Key = '0']", expected: "")
   }
@@ -392,8 +400,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserConsentStatusForPurpose() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getUserConsentStatusForPurpose [ID = 'cookies']")
@@ -401,8 +409,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserConsentStatusForVendor() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getUserConsentStatusForVendor [ID = '217']")
@@ -410,8 +418,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserStatusForVendor() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getUserStatusForVendor [ID = '217']")
@@ -419,8 +427,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserConsentStatusForVendorAndRequiredPurpose() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     agreeToAll(in: app)
     
     tapButton(in: app, name: "getUserConsentStatusForVendorAndRequiredPurposes [ID = '217']")
@@ -428,8 +436,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserLegitimateInterestStatusForPurpose() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     tapButton(in: app, name: "getUserLegitimateInterestStatusForPurpose [ID = 'cookies']")
@@ -437,8 +445,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserLegitimateInterestStatusForVendor() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     tapButton(in: app, name: "getUserLegitimateInterestStatusForVendor [ID = '217']")
@@ -446,8 +454,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetJavaScriptForWebViewWithExtra() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     let expected = """
@@ -469,8 +477,8 @@ class DidomiExampleUITests: XCTestCase {
   }
   
   func testGetUserLegitimateInterestStatusForVendorAndRequiredPurposes() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     resetUserStatus(in: app)
     
     tapButton(in: app, name: "getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '217']")
@@ -480,22 +488,22 @@ class DidomiExampleUITests: XCTestCase {
   // MARK: SETTERS
   
   func testSetUserStatusSets() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserStatusSets")
     assertResult(in: app, name: "setUserStatusSets", expected: "setUserStatusSets-OK")
   }
   
   func testSetUserAgreeToAll() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserAgreeToAll")
     assertResult(in: app, name: "setUserAgreeToAll", expected: "setUserAgreeToAll-OK")
   }
   
   func testSetUserDisagreeToAll() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserDisagreeToAll")
     assertResult(in: app, name: "setUserDisagreeToAll", expected: "setUserDisagreeToAll-OK")
   }
@@ -503,78 +511,78 @@ class DidomiExampleUITests: XCTestCase {
   // MARK: SET USER
   
   func testClearUser() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "clearUser")
     assertResult(in: app, name: "clearUser", expected: "clearUser-OK")
   }
   
   func testSetUserWithId() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithId")
     assertResult(in: app, name: "setUserWithId", expected: "setUserWithId-OK")
   }
   
   func testSetUserWithIdAndSetupUI() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithIdAndSetupUI")
     assertResult(in: app, name: "setUserWithIdAndSetupUI", expected: "setUserWithIdAndSetupUI-OK")
   }
   
   func testSetUserWithHashAuth() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithHashAuth")
     assertResult(in: app, name: "setUserWithHashAuth", expected: "setUserWithHashAuth-OK")
   }
   
   func testSetUserWithHashAuthAndSetupUI() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithHashAuthAndSetupUI")
     assertResult(in: app, name: "setUserWithHashAuthAndSetupUI", expected: "setUserWithHashAuthAndSetupUI-OK")
   }
   
   func testSetUserWithHashAuthWithSaltAndExpiration() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithHashAuthWithSaltAndExpiration")
     assertResult(in: app, name: "setUserWithHashAuthWithSaltAndExpiration", expected: "setUserWithHashAuthWithSaltAndExpiration-OK")
   }
   
   func testSetUserWithHashAuthWithSaltAndExpirationAndSetupUI() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithHashAuthWithSaltAndExpirationAndSetupUI")
     assertResult(in: app, name: "setUserWithHashAuthWithSaltAndExpirationAndSetupUI", expected: "setUserWithHashAuthWithSaltAndExpirationAndSetupUI-OK")
   }
   
   func testSetUserWithEncryptionAuth() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithEncryptionAuth")
     assertResult(in: app, name: "setUserWithEncryptionAuth", expected: "setUserWithEncryptionAuth-OK")
   }
   
   func testSetUserWithEncryptionAuthAndSetupUI() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithEncryptionAuthAndSetupUI")
     assertResult(in: app, name: "setUserWithEncryptionAuthAndSetupUI", expected: "setUserWithEncryptionAuthAndSetupUI-OK")
   }
   
   func testSetUserWithEncryptionAuthWithExpiration() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithEncryptionAuthWithExpiration")
     assertResult(in: app, name: "setUserWithEncryptionAuthWithExpiration", expected: "setUserWithEncryptionAuthWithExpiration-OK")
   }
   
   func testSetUserWithEncryptionAuthWithExpirationAndSetupUI() throws {
-    let app = XCUIApplication()
-    
+    let app = initApp()
+
     tapButton(in: app, name: "setUserWithEncryptionAuthWithExpirationAndSetupUI")
     assertResult(in: app, name: "setUserWithEncryptionAuthWithExpirationAndSetupUI", expected: "setUserWithEncryptionAuthWithExpirationAndSetupUI-OK")
   }

--- a/testApp/ios/DidomiExampleUITests/models/VendorData.swift
+++ b/testApp/ios/DidomiExampleUITests/models/VendorData.swift
@@ -13,5 +13,12 @@ struct VendorData: Decodable {
   let name: String
   let iabId: String
   let namespace: String
-  let policyUrl: String
+  let policyUrl: String?
+}
+
+// Vendor URLs structure since TCF 2.2
+struct VendorURLData: Decodable {
+  let langId: String
+  let privacy: String
+  let legIntClaim: String
 }

--- a/testApp/src/App.tsx
+++ b/testApp/src/App.tsx
@@ -80,12 +80,13 @@ function App() {
 
     async function init() {
       await Didomi.initialize(
-        '465ca0b2-b96f-43b4-a864-f87e18d2fd38',
+        '9bf8a7e4-db9a-4ff2-a45c-ab7d2b6eadba',
         undefined,
         undefined,
         undefined,
-        true,
+        false,
         undefined,
+        "Ar7NPQ72",
         undefined
       );
       console.log('Finished init');

--- a/testApp/src/App.tsx
+++ b/testApp/src/App.tsx
@@ -18,7 +18,9 @@ function App() {
 
   const registerListener = (eventType: DidomiEventType) => {
     Didomi.addEventListener(eventType, (data: any) => {
-      setReceivedEvent({ name: eventType, data });
+      if (eventType != "on_sync_done") { // TODO To allow testing other events, could be printed somewhere else
+        setReceivedEvent({ name: eventType, data });
+      }
       console.log('event received: ' + eventType);
       if (typeof data != "undefined" && data != "") {
         console.log(' -> data : ' + data);
@@ -79,6 +81,7 @@ function App() {
     });*/
 
     async function init() {
+      await Didomi.clearUser();
       await Didomi.initialize(
         '9bf8a7e4-db9a-4ff2-a45c-ab7d2b6eadba',
         undefined,

--- a/testApp/src/App.tsx
+++ b/testApp/src/App.tsx
@@ -81,7 +81,6 @@ function App() {
     });*/
 
     async function init() {
-      await Didomi.clearUser();
       await Didomi.initialize(
         '9bf8a7e4-db9a-4ff2-a45c-ab7d2b6eadba',
         undefined,

--- a/testApp/src/GettersParams.tsx
+++ b/testApp/src/GettersParams.tsx
@@ -37,9 +37,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getVendor [ID = '217'] policyUrl"
+        name="getVendor [ID = '217'] urls[0]"
         call={async () => {
-          return (await Didomi.getVendor('217')).policyUrl;
+          return (await Didomi.getVendor('217')).urls[0];
         }}
         test={() => {
           return true;

--- a/testApp/src/GettersParams.tsx
+++ b/testApp/src/GettersParams.tsx
@@ -17,9 +17,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getPurpose [ID = 'cookies'] descriptionLegal"
+        name="getPurpose [ID = 'cookies'] illustrations[0]"
         call={async () => {
-          return (await Didomi.getPurpose('cookies')).descriptionLegal;
+          return (await Didomi.getPurpose('cookies')).illustrations[0];
         }}
         test={() => {
           return true;
@@ -27,9 +27,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getVendor [ID = '755']"
+        name="getVendor [ID = '217']"
         call={async () => {
-          return await Didomi.getVendor('755');
+          return await Didomi.getVendor('217');
         }}
         test={() => {
           return true;
@@ -37,9 +37,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getVendor [ID = '755'] policyUrl"
+        name="getVendor [ID = '217'] policyUrl"
         call={async () => {
-          return (await Didomi.getVendor('755')).policyUrl;
+          return (await Didomi.getVendor('217')).policyUrl;
         }}
         test={() => {
           return true;
@@ -77,9 +77,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getUserConsentStatusForVendor [ID = '755']"
+        name="getUserConsentStatusForVendor [ID = '217']"
         call={async () => {
-          return await Didomi.getUserConsentStatusForVendor('755');
+          return await Didomi.getUserConsentStatusForVendor('217');
         }}
         test={() => {
           return true;
@@ -87,9 +87,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getUserStatusForVendor [ID = '755']"
+        name="getUserStatusForVendor [ID = '217']"
         call={async () => {
-          return await Didomi.getUserStatusForVendor('755');
+          return await Didomi.getUserStatusForVendor('217');
         }}
         test={() => {
           return true;
@@ -97,9 +97,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getUserConsentStatusForVendorAndRequiredPurposes [ID = '755']"
+        name="getUserConsentStatusForVendorAndRequiredPurposes [ID = '217']"
         call={async () => {
-          return await Didomi.getUserConsentStatusForVendorAndRequiredPurposes('755');
+          return await Didomi.getUserConsentStatusForVendorAndRequiredPurposes('217');
         }}
         test={() => {
           return true;
@@ -117,9 +117,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getUserLegitimateInterestStatusForVendor [ID = '755']"
+        name="getUserLegitimateInterestStatusForVendor [ID = '217']"
         call={async () => {
-          return await Didomi.getUserLegitimateInterestForVendor('755');
+          return await Didomi.getUserLegitimateInterestForVendor('217');
         }}
         test={() => {
           return true;
@@ -127,9 +127,9 @@ export default function GettersParams() {
       />
 
       <GetterParams
-        name="getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '755']"
+        name="getUserLegitimateInterestStatusForVendorAndRequiredPurposes [ID = '217']"
         call={async () => {
-          return await Didomi.getUserLegitimateInterestStatusForVendorAndRequiredPurposes('755');
+          return await Didomi.getUserLegitimateInterestStatusForVendorAndRequiredPurposes('217');
         }}
         test={() => {
           return true;


### PR DESCRIPTION
- Fix Android bridge to get TCF 2.2 vendors
- Update Vendors and Purposes structure
- Use remote config instead of local file in `testApp` 