### PR TITLE
Fix OutOfMemoryError in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
         gcloud firebase test android run --type instrumentation \
         --app android/app/build/outputs/apk/debug/app-debug.apk \
         --test android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+        --use-orchestrator \
         --device model=MediumPhone.arm,version=33,locale=en,orientation=portrait \
         --num-flaky-test-attempts=3
   

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
@@ -31,17 +31,13 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithId() {
         tapButton("setUserWithId")
         Thread.sleep(2_000L)
         assertText("setUserWithId-OK")
     }
 
-    // TODO Tests are ignored because of a OutOfMemoryError happening only on Firebase, to be investigated
-
     @Test
-    @Ignore
     fun test_SetUserWithIdAndSetupUI() {
         tapButton("setUserWithIdAndSetupUI")
         Thread.sleep(2_000L)
@@ -49,7 +45,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithHashAuth() {
         tapButton("setUserWithHashAuth")
         Thread.sleep(2_000L)
@@ -57,7 +52,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithHashAuthAndSetupUI() {
         tapButton("setUserWithHashAuthAndSetupUI")
         Thread.sleep(2_000L)
@@ -65,7 +59,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithHashAuthWithSaltAndExpiration() {
         tapButton("setUserWithHashAuthWithSaltAndExpiration")
         Thread.sleep(2_000L)
@@ -73,7 +66,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithHashAuthWithSaltAndExpirationAndSetupUI() {
         tapButton("setUserWithHashAuthWithSaltAndExpirationAndSetupUI")
         Thread.sleep(2_000L)
@@ -81,7 +73,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithEncryptionAuth() {
         tapButton("setUserWithEncryptionAuth")
         Thread.sleep(2_000L)
@@ -89,7 +80,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithEncryptionAuthAndSetupUI() {
         tapButton("setUserWithEncryptionAuthAndSetupUI")
         Thread.sleep(2_000L)
@@ -97,7 +87,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithEncryptionAuthWithExpiration() {
         tapButton("setUserWithEncryptionAuthWithExpiration")
         Thread.sleep(2_000L)
@@ -108,7 +97,6 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
-    @Ignore
     fun test_SetUserWithEncryptionAuthWithExpirationAndSetupUI() {
         tapButton("setUserWithEncryptionAuthWithExpirationAndSetupUI")
         Thread.sleep(2_000L)

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.filters.LargeTest
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
Use Tests Orchestrator to avoid running all the Android tests in the same application session. Initializing the SDK too many times triggered a `OutOfMemoryError` on Android.