### PR TITLE
Prepare 2 3 0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
   test_ios:
     name: Testing iOS
     needs: test_js
-    runs-on: macos-latest
+    runs-on: macos-12
     defaults:
       run:
         working-directory: testApp

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   update:
     name: Update version and dependencies
-    runs-on: macos-latest # required for pod info / update
+    runs-on: macos-12 # required for pod info / update
 
     steps:
       - name: Checkout

--- a/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
+++ b/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
@@ -645,15 +645,14 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
-            UserAuthWithHashParams(
+            userAuthParams = UserAuthWithHashParams(
                 organizationUserId,
                 algorithm,
                 secretId,
                 digest,
                 salt
             ),
-            null,
-            currentActivity as? FragmentActivity
+            activity = currentActivity as? FragmentActivity
         )
         promise.resolve(0)
     }
@@ -692,7 +691,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
-            UserAuthWithHashParams(
+            userAuthParams = UserAuthWithHashParams(
                 organizationUserId,
                 algorithm,
                 secretId,
@@ -700,8 +699,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 salt,
                 expiration.toLong()
             ),
-            null,
-            currentActivity as? FragmentActivity
+            activity = currentActivity as? FragmentActivity
         )
         promise.resolve(0)
     }
@@ -734,14 +732,13 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
-            UserAuthWithEncryptionParams(
+            userAuthParams = UserAuthWithEncryptionParams(
                 organizationUserId,
                 algorithm,
                 secretId,
                 initializationVector
             ),
-            null,
-            currentActivity as? FragmentActivity
+            activity = currentActivity as? FragmentActivity
         )
         promise.resolve(0)
     }
@@ -777,15 +774,14 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
-            UserAuthWithEncryptionParams(
+            userAuthParams = UserAuthWithEncryptionParams(
                 organizationUserId,
                 algorithm,
                 secretId,
                 initializationVector,
                 expiration.toLong()
             ),
-            null,
-            currentActivity as? FragmentActivity
+            activity = currentActivity as? FragmentActivity
         )
         promise.resolve(0)
     }

--- a/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
+++ b/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
@@ -652,6 +652,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 digest,
                 salt
             ),
+            null,
             currentActivity as? FragmentActivity
         )
         promise.resolve(0)
@@ -699,6 +700,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 salt,
                 expiration.toLong()
             ),
+            null,
             currentActivity as? FragmentActivity
         )
         promise.resolve(0)
@@ -738,6 +740,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 secretId,
                 initializationVector
             ),
+            null,
             currentActivity as? FragmentActivity
         )
         promise.resolve(0)
@@ -781,6 +784,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 initializationVector,
                 expiration.toLong()
             ),
+            null,
             currentActivity as? FragmentActivity
         )
         promise.resolve(0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react-native",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "Didomi React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Fix `macos-latest` still used in some places for iOS pipeline
- Fix Android calls to `setUser` after SDK update