### PR TITLE
CMP-4658 Create Types and new Functions for `SetUser` with authentication params

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,5 +124,5 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    implementation "io.didomi.sdk:android:2.6.0"
+    implementation "io.didomi.sdk:android:2.6.1"
 }

--- a/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
+++ b/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
@@ -261,7 +261,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         val set = mutableSetOf<String>()
 
         for (i in 0 until size()) {
-            set.add(getString(i).orEmpty())
+            set.add(getString(i))
         }
 
         return set

--- a/ios/Didomi.m
+++ b/ios/Didomi.m
@@ -81,16 +81,6 @@ RCT_EXTERN_METHOD(setUserAgreeToAll:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(setUserDisagreeToAll:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-//    @objc(onReady:)
-//    func onReady(callback: @escaping RCTResponseSenderBlock) {
-//        Didomi.shared.onReady(callback: callback)
-//    }
-
-//    @objc(onError:)
-//    func onError(callback: @escaping (Didomi.DidomiErrorEvent)) {
-//        Didomi.shared.onError(callback: callback)
-//    }
-
 RCT_EXTERN_METHOD(reset:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/Didomi.m
+++ b/ios/Didomi.m
@@ -234,6 +234,16 @@ RCT_EXTERN_METHOD(setUserWithEncryptionAuthWithExpirationAndSetupUI:(NSString *)
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setUserWithAuthParams:(NSString *)jsonUserAuthParams
+                  jsonSynchronizedUsers:(NSString)jsonSynchronizedUsers
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setUserWithAuthParamsAndSetupUI:(NSString *)jsonUserAuthParams
+                  jsonSynchronizedUsers:(NSString)jsonSynchronizedUsers
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(listenToVendorStatus:(NSString *)vendorId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/react-native-didomi.podspec
+++ b/react-native-didomi.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Didomi-XCFramework", "2.6.0"
+  s.dependency "Didomi-XCFramework", "2.7.1"
 end

--- a/src/Didomi.ts
+++ b/src/Didomi.ts
@@ -604,9 +604,9 @@ export const Didomi = {
   },
 
   /**
-   *  Set user information with Encryption authentication
+   *  Set user information with authentication (Hash or Encryption)
    *
-   *  @param userAuthParams as UserAuthParams
+   *  @param userAuthParams as UserAuthParams (use UserAuthWithEncryptionParams or UserAuthWithHashParams)
    *  @param synchronizedUsers as UserAuthParams[] (optional)
    */
   setUserWithAuthParams: (
@@ -615,9 +615,9 @@ export const Didomi = {
   ): void => RNDidomi.setUserWithAuthParams(JSON.stringify(userAuthParams), JSON.stringify(synchronizedUsers)),
 
   /**
-   *  Set user information with Encryption authentication and check for missing consent
+   *  Set user information with authentication (Hash or Encryption) and check for missing consent
    *
-   *  @param userAuthParams as UserAuthParams
+   *  @param userAuthParams as UserAuthParams (use UserAuthWithEncryptionParams or UserAuthWithHashParams)
    *  @param synchronizedUsers as UserAuthParams[] (optional)
    */
   setUserWithAuthParamsAndSetupUI: (

--- a/src/Didomi.ts
+++ b/src/Didomi.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { DidomiListener } from './DidomiListener';
-import { DidomiEventType, Purpose, Vendor, UserStatus, CurrentUserStatus, VendorStatus } from './DidomiTypes';
+import { DidomiEventType, Purpose, Vendor, UserStatus, CurrentUserStatus, VendorStatus, UserAuthParams } from './DidomiTypes';
 import { DIDOMI_USER_AGENT_NAME, DIDOMI_VERSION } from './Constants';
 import { CurrentUserStatusTransaction, createCurrentUserStatusTransaction } from './CurrentUserStatusTransaction';
 
@@ -464,6 +464,7 @@ export const Didomi = {
    *  @param digest Digest of the organization user ID and secret
    *  @param salt Salt used for computing the digest (optional)
    *  @param expiration Expiration date as timestamp (to prevent replay attacks)
+   *  @deprecated use {@link #setUserWithAuthParams()} instead.
    */
   setUserWithHashAuth: (
     id: string,
@@ -502,6 +503,7 @@ export const Didomi = {
    *  @param digest Digest of the organization user ID and secret
    *  @param salt Salt used for computing the digest (optional)
    *  @param expiration Expiration date as timestamp (to prevent replay attacks)
+   *  @deprecated use {@link #setUserWithAuthParamsAndSetupUI()} instead.
    */
   setUserWithHashAuthAndSetupUI: (
     id: string,
@@ -539,6 +541,7 @@ export const Didomi = {
    *  @param secretId ID of the secret used for computing the digest
    *  @param initializationVector Initialization Vector used for computing the user ID
    *  @param expiration Expiration date as timestamp (to prevent replay attacks)
+   *  @deprecated use {@link #setUserWithAuthParams()} instead.
    */
   setUserWithEncryptionAuth: (
     id: string,
@@ -573,6 +576,7 @@ export const Didomi = {
    *  @param secretId ID of the secret used for computing the digest
    *  @param initializationVector Initialization Vector used for computing the user ID
    *  @param expiration Expiration date as timestamp (to prevent replay attacks)
+   *  @deprecated use {@link #setUserWithAuthParamsAndSetupUI()} instead.
    */
   setUserWithEncryptionAuthAndSetupUI: (
     id: string,
@@ -598,6 +602,28 @@ export const Didomi = {
       );
     }
   },
+
+  /**
+   *  Set user information with Encryption authentication
+   *
+   *  @param userAuthParams as UserAuthParams
+   *  @param synchronizedUsers as UserAuthParams[] (optional)
+   */
+  setUserWithAuthParams: (
+    userAuthParams: UserAuthParams,
+    synchronizedUsers?: UserAuthParams[] | undefined
+  ): void => RNDidomi.setUserWithAuthParams(JSON.stringify(userAuthParams), JSON.stringify(synchronizedUsers)),
+
+  /**
+   *  Set user information with Encryption authentication and check for missing consent
+   *
+   *  @param userAuthParams as UserAuthParams
+   *  @param synchronizedUsers as UserAuthParams[] (optional)
+   */
+  setUserWithAuthParamsAndSetupUI: (
+    userAuthParams: UserAuthParams,
+    synchronizedUsers?: UserAuthParams[] | undefined
+  ): void => RNDidomi.setUserWithAuthParamsAndSetupUI(JSON.stringify(userAuthParams), JSON.stringify(synchronizedUsers)),
 
   /**
    * Show the consent notice (if required, not disabled in the config and not already displayed)

--- a/src/DidomiTypes.ts
+++ b/src/DidomiTypes.ts
@@ -153,3 +153,19 @@ export interface SyncReadyEvent {
   statusApplied: boolean;
   syncAcknowledged: () => Promise<boolean>;
 }
+
+export interface UserAuthParams {
+  id: string;
+  algorithm: string;
+  secretId: string;
+  expiration?: number;
+}
+
+export interface UserAuthWithEncryptionParams extends UserAuthParams {
+  initializationVector: string;
+}
+
+export interface UserAuthWithHashParams extends UserAuthParams {
+  digest: string;
+  salt?: string;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,16 @@
 export { Didomi } from './Didomi';
-export { DidomiEventType, Vendor, VendorNamespaces, Purpose, UserStatus, UserStatusPurposes, UserStatusVendors, UserStatusIds, CurrentUserStatus, PurposeStatus, VendorStatus } from './DidomiTypes';
+export {
+    DidomiEventType,
+    Vendor,
+    VendorNamespaces,
+    Purpose,
+    UserStatus,
+    UserStatusPurposes,
+    UserStatusVendors,
+    UserStatusIds,
+    CurrentUserStatus,
+    PurposeStatus,
+    VendorStatus,
+    UserAuthWithEncryptionParams,
+    UserAuthWithHashParams
+} from './DidomiTypes';

--- a/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
+++ b/testApp/android/app/src/androidTest/java/com/example/reactnativedidomi/UISetUserTest.kt
@@ -105,6 +105,34 @@ class UISetUserTest: BaseUITest() {
     }
 
     @Test
+    fun test_SetUserWithHashAuthWithSynchronizedUsers() {
+        tapButton("setUserWithHashAuthWithSynchronizedUsers")
+        Thread.sleep(2_000L)
+        assertText("setUserWithHashAuthWithSynchronizedUsers-OK")
+    }
+
+    @Test
+    fun test_SetUserWithHashAuthWithSynchronizedUsersAndSetupUI() {
+        tapButton("setUserWithHashAuthWithSynchronizedUsersAndSetupUI")
+        Thread.sleep(2_000L)
+        assertText("setUserWithHashAuthWithSynchronizedUsersAndSetupUI-OK")
+    }
+
+    @Test
+    fun test_SetUserWithEncryptionAuthWithSynchronizedUsers() {
+        tapButton("setUserWithEncryptionAuthWithSynchronizedUsers")
+        Thread.sleep(2_000L)
+        assertText("setUserWithEncryptionAuthWithSynchronizedUsers-OK")
+    }
+
+    @Test
+    fun test_SetUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI() {
+        tapButton("setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI")
+        Thread.sleep(2_000L)
+        assertText("setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI-OK")
+    }
+
+    @Test
     fun test_SyncReadyEvent() {
         tapButton("Listen user sync")
         EspressoViewFinder.waitForDisplayed(withText("Listen user sync-OK"))

--- a/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
+++ b/testApp/ios/DidomiExampleUITests/DidomiExampleUITests.swift
@@ -695,6 +695,34 @@ class DidomiExampleUITests: XCTestCase {
     assertResult(in: app, name: "setUserWithEncryptionAuthWithExpirationAndSetupUI", expected: "setUserWithEncryptionAuthWithExpirationAndSetupUI-OK")
   }
   
+  func testSetUserWithHashAuthWithSynchronizedUsers() throws {
+    let app = initApp()
+
+    tapButton(in: app, name: "setUserWithHashAuthWithSynchronizedUsers")
+    assertResult(in: app, name: "setUserWithHashAuthWithSynchronizedUsers", expected: "setUserWithHashAuthWithSynchronizedUsers-OK")
+  }
+  
+  func testSetUserWithHashAuthWithSynchronizedUsersAndSetupUI() throws {
+    let app = initApp()
+
+    tapButton(in: app, name: "setUserWithHashAuthWithSynchronizedUsersAndSetupUI")
+    assertResult(in: app, name: "setUserWithHashAuthWithSynchronizedUsersAndSetupUI", expected: "setUserWithHashAuthWithSynchronizedUsersAndSetupUI-OK")
+  }
+  
+  func testSetUserWithEncryptionAuthWithSynchronizedUsers() throws {
+    let app = initApp()
+
+    tapButton(in: app, name: "setUserWithEncryptionAuthWithSynchronizedUsers")
+    assertResult(in: app, name: "setUserWithEncryptionAuthWithSynchronizedUsers", expected: "setUserWithEncryptionAuthWithSynchronizedUsers-OK")
+  }
+  
+  func testSetUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI() throws {
+    let app = initApp()
+
+    tapButton(in: app, name: "setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI")
+    assertResult(in: app, name: "setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI", expected: "setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI-OK")
+  }
+  
   func testSyncReadyEvent() throws {
     let app = initApp()
 

--- a/testApp/scripts/android/prepare-ui-tests-locally-android.sh
+++ b/testApp/scripts/android/prepare-ui-tests-locally-android.sh
@@ -1,4 +1,13 @@
+# Delete `package-lock.json` and `yarn.lock`
+(
+  [ -f package-lock.json ] && rm package-lock.json && echo "package-lock.json deleted"
+  [ -f yarn.lock ] && rm yarn.lock && echo "yarn.lock deleted"
+)
+
 yarn install
-cd android && chmod +x ./gradlew
-cd ..
+
+#  Makes gradlew executable
+chmod +x ./android/gradlew
+
+#  Build the test app
 npx react-native bundle --platform android --dev false --entry-file index.tsx --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/

--- a/testApp/scripts/ios/prepare-ui-tests-locally-ios.sh
+++ b/testApp/scripts/ios/prepare-ui-tests-locally-ios.sh
@@ -1,5 +1,16 @@
+# Delete `package-lock.json` and `yarn.lock`
+(
+  [ -f package-lock.json ] && rm package-lock.json && echo "package-lock.json deleted"
+  # Comment this line locally because of failure with Xcode 15 (Yoga.cpp needs to be updated to work with Xcode 15)
+#   [ -f yarn.lock ] && rm yarn.lock && echo "yarn.lock deleted"
+)
+
 yarn install
-cd ios && pod update && pod install && cd ..
+
+# Update pods
+pod update --project-directory=./ios && pod install --project-directory=./ios
+
+# Build Test App
 cp index.tsx index.js
 npx react-native bundle --entry-file index.js --platform ios --dev false --bundle-output ios/main.jsbundle --assets-dest ios/assets
 rm index.js

--- a/testApp/src/SetUser.tsx
+++ b/testApp/src/SetUser.tsx
@@ -44,7 +44,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithHashAuth"
         call={async () => {
-          return Didomi.setUserWithHashAuth(userId, "hash-md5", secretId, "test-digest");
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest"};
+          return Didomi.setUserWithAuthParams(userAuthParams);
         }}
         test={() => {
           return true;
@@ -54,7 +55,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithHashAuthAndSetupUI"
         call={async () => {
-          return Didomi.setUserWithHashAuthAndSetupUI(userId, "hash-md5", secretId, "test-digest");
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest"};
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams);
         }}
         test={() => {
           return true;
@@ -64,7 +66,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithHashAuthWithSaltAndExpiration"
         call={async () => {
-          return Didomi.setUserWithHashAuth(userId, "hash-md5", secretId, "test-digest", "test-salt", 3600);
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest", salt: "test-salt", expiration: 3600};
+          return Didomi.setUserWithAuthParams(userAuthParams);
         }}
         test={() => {
           return true;
@@ -74,7 +77,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithHashAuthWithSaltAndExpirationAndSetupUI"
         call={async () => {
-          return Didomi.setUserWithHashAuthAndSetupUI(userId, "hash-md5", secretId, "test-digest", "test-salt", 3600);
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest", salt: "test-salt", expiration: 3600};
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams);
         }}
         test={() => {
           return true;
@@ -84,7 +88,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithEncryptionAuth"
         call={async () => {
-          return Didomi.setUserWithEncryptionAuth(userId, "aes-256-cbc", secretId, "abcd");
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"};
+          return Didomi.setUserWithAuthParams(userAuthParams);
         }}
         test={() => {
           return true;
@@ -94,7 +99,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithEncryptionAuthAndSetupUI"
         call={async () => {
-          return Didomi.setUserWithEncryptionAuthAndSetupUI(userId, "aes-256-cbc", secretId, "abcd");
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"};
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams);
         }}
         test={() => {
           return true;
@@ -104,7 +110,8 @@ export default function SetUser() {
       <Setter
         name="setUserWithEncryptionAuthWithExpiration"
         call={async () => {
-          return Didomi.setUserWithEncryptionAuth(userId, "aes-256-cbc", secretId, "abcd", 3600);
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+          return Didomi.setUserWithAuthParams(userAuthParams);
         }}
         test={() => {
           return true;
@@ -114,7 +121,76 @@ export default function SetUser() {
       <Setter
         name="setUserWithEncryptionAuthWithExpirationAndSetupUI"
         call={async () => {
-          return Didomi.setUserWithEncryptionAuthAndSetupUI(userId, "aes-256-cbc", secretId, "abcd", 3600);
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams);
+        }}
+        test={() => {
+          return true;
+        }}
+      />
+
+      <Setter
+        name="setUserWithHashAuthWithSynchronizedUsers"
+        call={async () => {
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest"};
+
+          var synchronizedUsers = [
+            {id: userId + "1", algorithm: "hash-md5", secretId: secretId, digest: "test-digest"},
+            {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
+          ];
+
+          return Didomi.setUserWithAuthParams(userAuthParams, synchronizedUsers);
+        }}
+        test={() => {
+          return true;
+        }}
+      />
+
+      <Setter
+        name="setUserWithHashAuthWithSynchronizedUsersAndSetupUI"
+        call={async () => {
+          var userAuthParams = {id: userId, algorithm: "hash-md5", secretId: secretId, digest: "test-digest"};
+
+          var synchronizedUsers = [
+            {id: userId + "1", algorithm: "hash-md5", secretId: secretId, digest: "test-digest"},
+            {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
+          ];
+
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams, synchronizedUsers);
+        }}
+        test={() => {
+          return true;
+        }}
+      />
+
+      <Setter
+        name="setUserWithEncryptionAuthWithSynchronizedUsers"
+        call={async () => {
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+
+          var synchronizedUsers = [
+            {id: userId + "1", algorithm: "hash-md5", secretId: secretId, digest: "test-digest"},
+            {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
+          ];
+
+          return Didomi.setUserWithAuthParams(userAuthParams, synchronizedUsers);
+        }}
+        test={() => {
+          return true;
+        }}
+      />
+
+      <Setter
+        name="setUserWithEncryptionAuthWithSynchronizedUsersAndSetupUI"
+        call={async () => {
+          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+
+          var synchronizedUsers = [
+            {id: userId + "1", algorithm: "hash-md5", secretId: secretId, digest: "test-digest"},
+            {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
+          ];
+
+          return Didomi.setUserWithAuthParamsAndSetupUI(userAuthParams, synchronizedUsers);
         }}
         test={() => {
           return true;


### PR DESCRIPTION
- Update native SDKs
- Cleanup lock file during tests setup scripts (keep `yarn.lock` for iOS tests because of current version of RN build fails with Xcode 15 - Yoga.cpp must be edited).
- Implement new Types for `UserAuthParams`.
- Implement new functions `setUserWithAuthParams` and `setUserWithAuthParamsAndSetupUI`.
- Deprecate existing RN functions `setUserWithHashAuth`, `setUserWithHashAuthAndSetupUI`, `setUserWithEncryptionAuth`, `setUserWithEncryptionAuthAndSetupUI`.
- New tests.