### PR TITLE
Fix wrong values types in objectToWritableMap on Android

### DIFF
--- a/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
+++ b/android/src/main/java/com/reactnativedidomi/DidomiModule.kt
@@ -309,6 +309,9 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                         map.putArray(entry.key, Arguments.makeNativeArray(listValues))
                     }
                 }
+                is Boolean -> map.putBoolean(entry.key, value)
+                is Int -> map.putInt(entry.key, value)
+                is Double -> map.putDouble(entry.key, value)
                 else -> map.putString(entry.key, value.toString())
             }
         }


### PR DESCRIPTION
Make sure Android objects fields have the correct type when they are passed to react-native.

Fixes https://github.com/didomi/react-native/issues/120