### PR TITLE
Fix / update scripts used for versions

### DIFF
--- a/.github/scripts/check_before_update.sh
+++ b/.github/scripts/check_before_update.sh
@@ -7,13 +7,21 @@
 
 # Get last version from pod
 pod_last_version() {
-  lastversion=""
-  for line in $(pod trunk info Didomi-XCFramework); do
-    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      lastversion=$line
+  version=""
+  temp_file=$(mktemp)
+  pod trunk info Didomi-XCFramework > "$temp_file"
+  
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+      current_version="${BASH_REMATCH[1]}"
+      if [[ -z "$version" || $(printf '%s\n' "$version" "$current_version" | sort -V | tail -n1) == "$current_version" ]]; then
+        version=$current_version
+      fi
     fi
-  done
-  echo "$lastversion"
+  done < "$temp_file"
+  
+  rm "$temp_file"
+  echo "$version"
 }
 
 changes=0

--- a/.github/scripts/check_before_update.sh
+++ b/.github/scripts/check_before_update.sh
@@ -33,11 +33,12 @@ if [[ -z $currentVersion ]]; then
   exit 1
 fi
 
-lastVersion=$(curl -s 'https://search.maven.org/solrsearch/select?q=didomi' | sed -n 's|.*"latestVersion":"\([^"]*\)".*|\1|p')
-if [[ -z $lastVersion ]]; then
-  echo "Error while getting android SDK latest version"
+lastVersion=$(curl -s 'https://repo.maven.apache.org/maven2/io/didomi/sdk/android/maven-metadata.xml' | sed -ne '/release/{s/.*<release>\(.*\)<\/release>.*/\1/p;q;}')
+if [[ ! $lastVersion =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  echo "Error while getting android SDK version"
   exit 1
 fi
+
 
 if [[ "$currentVersion" == "$lastVersion" ]]; then
   echo "No change for Android SDK: $currentVersion"

--- a/.github/scripts/extract_android_sdk_version.sh
+++ b/.github/scripts/extract_android_sdk_version.sh
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 
 version=$(cat android/build.gradle | sed -n 's|.*io.didomi.sdk:android:\([^"]*\)".*|\1|p')
-if [[ -z $currentversion ]]; then
+if [[ -z $version ]]; then
   echo "Error while getting android SDK current version"
   exit 1
 fi

--- a/.github/scripts/update_native_sdks.sh
+++ b/.github/scripts/update_native_sdks.sh
@@ -7,11 +7,19 @@
 # Get last version from pod
 pod_last_version() {
   version=""
-  for line in $(pod trunk info Didomi-XCFramework); do
-    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      version=$line
+  temp_file=$(mktemp)
+  pod trunk info Didomi-XCFramework > "$temp_file"
+  
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+      current_version="${BASH_REMATCH[1]}"
+      if [[ -z "$version" || $(printf '%s\n' "$version" "$current_version" | sort -V | tail -n1) == "$current_version" ]]; then
+        version=$current_version
+      fi
     fi
-  done
+  done < "$temp_file"
+  
+  rm "$temp_file"
   echo "$version"
 }
 

--- a/react-native-didomi.podspec
+++ b/react-native-didomi.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Didomi-XCFramework", "2.9.2"
+  s.dependency "Didomi-XCFramework", "2.11.0"
 end


### PR DESCRIPTION
The current scripts were failing to get the latest iOS and Android SDKs versions.

Since the end points we are using to list available version are sorting the version number alphabetically, the very last version can be located inside the list and not at the bottom.
example:
```
      - 2.0.0 (2024-02-15 14:53:57 UTC)
      - 2.0.1 (2024-02-16 12:54:24 UTC)
      - 2.0.2 (2024-02-26 13:57:38 UTC)
      - 2.1.0 (2024-03-06 09:17:35 UTC)
      - 2.10.0 (2024-07-15 09:16:17 UTC)
      - 2.11.0 (2024-07-30 07:35:03 UTC)
      - 2.2.0 (2024-03-18 09:00:41 UTC)
      - 2.3.0 (2024-03-27 15:28:54 UTC)
      - 2.4.0 (2024-04-10 14:18:55 UTC)
      - 2.5.0 (2024-04-26 09:33:53 UTC)
      - 2.6.0 (2024-05-10 14:29:07 UTC)
      - 2.7.0 (2024-05-23 08:36:41 UTC)
      - 2.7.1 (2024-05-30 19:18:11 UTC)
      - 2.8.0 (2024-06-06 11:02:25 UTC)
      - 2.9.0 (2024-06-21 12:24:38 UTC)
      - 2.9.1 (2024-06-21 16:59:40 UTC)
      - 2.9.2 (2024-07-02 12:32:59 UTC)
```