### PR TITLE
CMP-4885: use correct type for userAuth property

### DIFF
--- a/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
@@ -1205,8 +1205,8 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         jsonParameters: JSONObject,
         activity: FragmentActivity? = null
     ): DidomiUserParameters {
-        val userAuthParams = if (jsonParameters.has("userAuthParams")) {
-            buildUserAuthParams(jsonParameters.getJSONObject("userAuthParams"))
+        val userAuth = if (jsonParameters.has("userAuth")) {
+            buildUserAuthParams(jsonParameters.getJSONObject("userAuth"))
         } else null
         
         val dcsUserAuth = if (jsonParameters.has("dcsUserAuth")) {
@@ -1218,7 +1218,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         if (jsonParameters.has("synchronizedUsers")) {
             val synchronizedUsers = buildUserAuthParamsArray(jsonParameters.getJSONArray("synchronizedUsers"))
             return DidomiMultiUserParameters(
-                userAuth = userAuthParams as UserAuth,
+                userAuth = userAuth as UserAuth,
                 dcsUserAuth = dcsUserAuth,
                 synchronizedUsers = synchronizedUsers,
                 activity = activity,
@@ -1226,7 +1226,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
             )
         } else {
             return DidomiUserParameters(
-                userAuth = userAuthParams as UserAuth,
+                userAuth = userAuth as UserAuth,
                 dcsUserAuth = dcsUserAuth,
                 activity = activity,
                 isUnderage = isUnderage

--- a/ios/RNDidomi.swift
+++ b/ios/RNDidomi.swift
@@ -972,15 +972,15 @@ extension RNDidomi {
     private func buildDidomiUserParameters(from jsonString: String, containerController: UIViewController? = nil) throws -> DidomiUserParameters {
         let json = try jsonString.toJSON()
         
-        let userAuthParamsJSON = json["userAuthParams"] as? [String: Any]
-        let userAuthParams = try buildUserAuthParams(from: userAuthParamsJSON)
-        let isUnderage = json["isUnderage"] as? Bool
+        let userAuthJSON = json["userAuth"] as? [String: Any]
+        let userAuth = try buildUserAuthParams(from: userAuthJSON)
         let dcsUserAuthJSON = json["dcsUserAuth"] as? [String: Any]
         let dcsUserAuth = try? buildUserAuthParams(from: dcsUserAuthJSON)
+        let isUnderage = json["isUnderage"] as? Bool
         
         if let synchronizedUsers = json["synchronizedUsers"] as? [[String: Any]] {
             return DidomiMultiUserParameters(
-                userAuth: userAuthParams,
+                userAuth: userAuth,
                 dcsUserAuth: dcsUserAuth,
                 synchronizedUsers: try synchronizedUsers.map { try buildUserAuthParams(from: $0) },
                 containerController: containerController,
@@ -988,7 +988,7 @@ extension RNDidomi {
             )
         } else {
             return DidomiUserParameters(
-                userAuth: userAuthParams,
+                userAuth: userAuth,
                 dcsUserAuth: dcsUserAuth,
                 containerController: containerController,
                 isUnderage: isUnderage

--- a/src/DidomiTypes.ts
+++ b/src/DidomiTypes.ts
@@ -178,8 +178,11 @@ export interface SyncReadyEvent {
   syncAcknowledged: () => Promise<boolean>;
 }
 
-export interface UserAuthParams {
+export interface UserAuth {
   id: string;
+}
+
+export interface UserAuthParams extends UserAuth {
   algorithm: string;
   secretId: string;
   expiration?: number;
@@ -282,7 +285,7 @@ export interface DidomiUserParameters {
    * - [UserAuthWithoutParams] (ID only)
    * @property
    */
-  userAuth?: UserAuthParams;
+  userAuth?: UserAuth;
   /**
    * User authentication for Didomi Consent String
    * - [UserAuthWithEncryptionParams] (encryption)

--- a/test/src/SetUser.tsx
+++ b/test/src/SetUser.tsx
@@ -201,7 +201,7 @@ export default function SetUser() {
         name="setUserWithParameters"
         call={async () => {
 
-          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+          var userAuth = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
 
           var dcsUserAuth = {id: userId + "-dcs", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
 
@@ -210,7 +210,7 @@ export default function SetUser() {
             {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
           ];
 
-          var parameters = {userAuthParams: userAuthParams, dcsUserAuth: dcsUserAuth, synchronizedUsers: synchronizedUsers, isUnderage: false};
+          var parameters = {userAuth: userAuth, dcsUserAuth: dcsUserAuth, synchronizedUsers: synchronizedUsers, isUnderage: false};
 
           return Didomi.setUserWithParameters(parameters);
         }}
@@ -222,14 +222,14 @@ export default function SetUser() {
       <Setter
         name="setUserWithParametersAndSetupUI"
         call={async () => {
-          var userAuthParams = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
+          var userAuth = {id: userId, algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd", expiration: 3600};
 
           var synchronizedUsers = [
             {id: userId + "1", algorithm: "hash-md5", secretId: secretId, digest: "test-digest"},
             {id: userId + "2", algorithm: "aes-256-cbc", secretId: secretId, initializationVector: "abcd"}
           ];
 
-          var parameters = {userAuthParams: userAuthParams, synchronizedUsers: synchronizedUsers, isUnderage: false};
+          var parameters = {userAuth: userAuth, synchronizedUsers: synchronizedUsers, isUnderage: false};
 
           return await Didomi.setUserWithParametersAndSetupUI(parameters);
         }}


### PR DESCRIPTION
Changes included:
- Use of correct name and type for `userAuth` property in `DidomiUserParameters`.
- Created new `UserAuth` type for consistency with native implementations.