### PR TITLE
fix: fix build error due to null safety error with kotlin compiler 2

### DIFF
--- a/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
@@ -268,7 +268,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         val set = mutableSetOf<String>()
 
         for (i in 0 until size()) {
-            set.add(getString(i))
+            getString(i)?.let { set.add(it) }
         }
 
         return set
@@ -1179,7 +1179,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
 
     // Required to transform from array to variadic.
     private fun readableArrayToStringArray(readableArray: ReadableArray): Array<String> {
-        return Array(readableArray.size()) { i -> readableArray.getString(i) }
+        return Array(readableArray.size()) { i -> readableArray.getString(i) ?: "" }
     }
 
     private fun buildDidomiInitializeParameters(jsonParameters: String): DidomiInitializeParameters {

--- a/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
@@ -268,7 +268,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         val set = mutableSetOf<String>()
 
         for (i in 0 until size()) {
-            getString(i)?.let { set.add(it) }
+            getString(i)?.also { set.add(it) }
         }
 
         return set
@@ -1178,9 +1178,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     // Required to transform from array to variadic.
-    private fun readableArrayToStringArray(readableArray: ReadableArray): Array<String> {
-        return Array(readableArray.size()) { i -> readableArray.getString(i) ?: "" }
-    }
+    private fun readableArrayToStringArray(readableArray: ReadableArray) = readableArray.toSet().toTypedArray()
 
     private fun buildDidomiInitializeParameters(jsonParameters: String): DidomiInitializeParameters {
         val jsonObject = JSONObject(jsonParameters)


### PR DESCRIPTION
## Description
 This PR fixes Kotlin type mismatch errors by properly handling nullable strings in two functions:
 
 - `toSet()` extension function now safely handles nullable strings from ReadableArray
 - `readableArrayToStringArray` function provides empty string fallback for null values
 
 ## Related Issues
 Fixes type mismatch errors where Kotlin expects non-null String but receives String?
 
 ## Testing
 - Tested with null string values
 - Verified existing functionality remains intact

resolves #146 