### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Node dependencies
         uses: actions/cache@v4
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -47,16 +47,16 @@ jobs:
         working-directory: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -94,7 +94,7 @@ jobs:
           cd android && ./gradlew assembleDebug --no-daemon
 
       - name: Upload Android App APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: app-debug.apk 
           path: test/android/app/build/outputs/apk/debug/app-debug.apk 
@@ -104,14 +104,14 @@ jobs:
           cd android && ./gradlew :app:assembleDebugAndroidTest --no-daemon
       
       - name: Upload Android Test APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: app-debug-androidTest.apk 
           path: test/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 
       # Authenticate Cloud SDK
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
   
@@ -144,10 +144,10 @@ jobs:
         working-directory: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
@@ -179,7 +179,7 @@ jobs:
       # Archive Result if failure
       - name: Archive iOS artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ios-test-results
           path: /Users/runner/Library/Developer/Xcode/DerivedData/**/*.xcresult
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Android SDK version as ENV
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set React Native version as ENV
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -47,16 +47,16 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -94,7 +94,7 @@ jobs:
           cd android && ./gradlew assembleDebug --no-daemon
 
       - name: Upload Android App APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: app-debug.apk 
           path: test/android/app/build/outputs/apk/debug/app-debug.apk 
@@ -104,7 +104,7 @@ jobs:
           cd android && ./gradlew :app:assembleDebugAndroidTest --no-daemon
       
       - name: Upload Android Test APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: app-debug-androidTest.apk 
           path: test/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
@@ -144,10 +144,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
@@ -179,7 +179,7 @@ jobs:
       # Archive Result if failure
       - name: Archive iOS artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ios-test-results
           path: /Users/runner/Library/Developer/Xcode/DerivedData/**/*.xcresult

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
@@ -36,7 +36,7 @@ jobs:
           bash .github/scripts/check_before_update.sh
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 


### PR DESCRIPTION
Update github action

Seems we need to update NPM version to use the new NPM.js authentication.

I'm updating all the major versions of the actions we are using in our workflows:
- actions/checkout@v6
- actions/setup-node@v6
- actions/setup-java@v5
- actions/upload-artifact@v5