### PR TITLE
Update new architecture support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
           node-version: 20
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -72,13 +72,13 @@ jobs:
         run: npm install
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -94,7 +94,7 @@ jobs:
           cd android && ./gradlew assembleDebug --no-daemon
 
       - name: Upload Android App APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug.apk 
           path: test/android/app/build/outputs/apk/debug/app-debug.apk 
@@ -104,7 +104,7 @@ jobs:
           cd android && ./gradlew :app:assembleDebugAndroidTest --no-daemon
       
       - name: Upload Android Test APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug-androidTest.apk 
           path: test/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
@@ -116,7 +116,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
   
       - name: Setup Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
           install_components: 'beta'
@@ -153,7 +153,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -179,7 +179,7 @@ jobs:
       # Archive Result if failure
       - name: Archive iOS artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results
           path: /Users/runner/Library/Developer/Xcode/DerivedData/**/*.xcresult

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-      
+
       - name: Run JS tests
         run: npm test
 
@@ -61,7 +61,7 @@ jobs:
           node-version: 20
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -72,13 +72,13 @@ jobs:
         run: npm install
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -94,7 +94,7 @@ jobs:
           cd android && ./gradlew assembleDebug --no-daemon
 
       - name: Upload Android App APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug.apk 
           path: test/android/app/build/outputs/apk/debug/app-debug.apk 
@@ -104,7 +104,7 @@ jobs:
           cd android && ./gradlew :app:assembleDebugAndroidTest --no-daemon
       
       - name: Upload Android Test APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug-androidTest.apk 
           path: test/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
@@ -116,7 +116,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Setup Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
           install_components: 'beta'
@@ -153,7 +153,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache Node dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -182,7 +182,7 @@ jobs:
       # Archive Result if failure
       - name: Archive iOS artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results
           path: /Users/runner/Library/Developer/Xcode/DerivedData/**/*.xcresult

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
+apply plugin: "com.facebook.react"
 
 def getExtOrDefault(name) {
     return project.properties["Didomi_" + name].toString()
@@ -26,12 +27,16 @@ def getExtOrIntegerDefault(name) {
     return project.properties["Didomi_" + name].toInteger()
 }
 
+def isNewArchitectureEnabled() {
+    return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
 def parsedPackage = new JsonSlurper().parseText(file("../package.json").text)
 
 android {
     compileSdk getExtOrIntegerDefault("compileSdkVersion")
     namespace "io.didomi.reactnative"
-    
+
     defaultConfig {
         minSdk getExtOrIntegerDefault("minSdkVersion")
         targetSdk getExtOrIntegerDefault("targetSdkVersion")
@@ -39,6 +44,22 @@ android {
         versionName "${parsedPackage.version}"
 
         multiDexEnabled = true
+
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    sourceSets {
+        main {
+            if (isNewArchitectureEnabled()) {
+                java.srcDirs += ['src/newarch/java']
+            } else {
+                java.srcDirs += ['src/oldarch/java']
+            }
+        }
     }
 
     buildTypes {
@@ -58,6 +79,12 @@ android {
         jvmTarget = JavaVersion.VERSION_17
     }
 
+}
+
+react {
+    jsRootDir = file("../src/specs")
+    libraryName = "RNDidomiSpec"
+    codegenJavaPackageName = "io.didomi.reactnative"
 }
 
 repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -158,5 +158,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation("com.google.code.gson:gson:2.13.1")
-    implementation "io.didomi.sdk:android:2.42.0"
+    implementation "io.didomi.sdk:android:2.43.0"
 }

--- a/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
@@ -331,7 +331,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun initialize(
+    override fun initialize(
         userAgentName: String,
         userAgentVersion: String,
         apiKey: String,
@@ -379,7 +379,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun initializeWithParameters(
+    override fun initializeWithParameters(
         userAgentName: String,
         userAgentVersion: String,
         jsonParameters: String,
@@ -403,19 +403,19 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun onReady(promise: Promise) {
+    override fun onReady(promise: Promise) {
         Didomi.getInstance().onReady { prepareEvent(EventTypes.READY_CALLBACK.event, null) }
         promise.resolve(0)
     }
 
     @ReactMethod
-    fun onError(promise: Promise) {
+    override fun onError(promise: Promise) {
         Didomi.getInstance().onError { prepareEvent(EventTypes.ERROR_CALLBACK.event, null) }
         promise.resolve(0)
     }
 
     @ReactMethod
-    fun setupUI(promise: Promise) {
+    override fun setupUI(promise: Promise) {
         try {
             runOnUiThread {
                 Didomi.getInstance().setupUI(reactContext.currentActivity as? FragmentActivity)
@@ -428,7 +428,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setLogLevel(level: Double, promise: Promise) {
+    override fun setLogLevel(level: Double, promise: Promise) {
         Didomi.getInstance().setLogLevel(
             when (level.toInt()) {
                 0 -> Log.INFO
@@ -443,7 +443,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getJavaScriptForWebView(extra: String?, promise: Promise) {
+    override fun getJavaScriptForWebView(extra: String?, promise: Promise) {
         try {
             extra?.also {
                 promise.resolve(Didomi.getInstance().getJavaScriptForWebView(extra))
@@ -456,7 +456,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getQueryStringForWebView(promise: Promise) {
+    override fun getQueryStringForWebView(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().queryStringForWebView)
         } catch (e: DidomiNotReadyException) {
@@ -465,7 +465,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getPurpose(purposeId: String, promise: Promise) {
+    override fun getPurpose(purposeId: String, promise: Promise) {
         try {
             promise.resolve(objectToWritableMap(Didomi.getInstance().getPurpose(purposeId)))
         } catch (e: DidomiNotReadyException) {
@@ -474,7 +474,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getRequiredPurposes(promise: Promise) {
+    override fun getRequiredPurposes(promise: Promise) {
         try {
             promise.resolve(setToWritableArray(Didomi.getInstance().requiredPurposes))
         } catch (e: DidomiNotReadyException) {
@@ -483,7 +483,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getRequiredPurposeIds(promise: Promise) {
+    override fun getRequiredPurposeIds(promise: Promise) {
         try {
             promise.resolve(setOfStringToWritableArray(Didomi.getInstance().requiredPurposeIds))
         } catch (e: DidomiNotReadyException) {
@@ -492,7 +492,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getVendor(vendorId: String, promise: Promise) {
+    override fun getVendor(vendorId: String, promise: Promise) {
         try {
             promise.resolve(objectToWritableMap(Didomi.getInstance().getVendor(vendorId)))
         } catch (e: DidomiNotReadyException) {
@@ -501,7 +501,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getTotalVendorCount(promise: Promise) {
+    override fun getTotalVendorCount(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().getTotalVendorCount())
         } catch (e: DidomiNotReadyException) {
@@ -510,7 +510,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getIabVendorCount(promise: Promise) {
+    override fun getIabVendorCount(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().getIabVendorCount())
         } catch (e: DidomiNotReadyException) {
@@ -519,7 +519,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getNonIabVendorCount(promise: Promise) {
+    override fun getNonIabVendorCount(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().getNonIabVendorCount())
         } catch (e: DidomiNotReadyException) {
@@ -528,7 +528,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getRequiredVendors(promise: Promise) {
+    override fun getRequiredVendors(promise: Promise) {
         try {
             promise.resolve(setToWritableArray(Didomi.getInstance().requiredVendors))
         } catch (e: DidomiNotReadyException) {
@@ -537,7 +537,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getRequiredVendorIds(promise: Promise) {
+    override fun getRequiredVendorIds(promise: Promise) {
         try {
             promise.resolve(setOfStringToWritableArray(Didomi.getInstance().requiredVendorIds))
         } catch (e: DidomiNotReadyException) {
@@ -546,7 +546,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getText(textKey: String, promise: Promise) {
+    override fun getText(textKey: String, promise: Promise) {
         try {
             val map = Didomi.getInstance().getText(textKey)
             val writableMap = WritableNativeMap()
@@ -562,7 +562,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getTranslatedText(key: String, promise: Promise) {
+    override fun getTranslatedText(key: String, promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().getTranslatedText(key))
         } catch (e: DidomiNotReadyException) {
@@ -571,7 +571,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getCurrentUserStatus(promise: Promise) {
+    override fun getCurrentUserStatus(promise: Promise) {
         try {
             promise.resolve(objectToWritableMap(Didomi.getInstance().currentUserStatus))
         } catch (e: DidomiNotReadyException) {
@@ -580,7 +580,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getUserStatus(promise: Promise) {
+    override fun getUserStatus(promise: Promise) {
         try {
             promise.resolve(objectToWritableMap(Didomi.getInstance().userStatus))
         } catch (e: DidomiNotReadyException) {
@@ -589,7 +589,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun getApplicableRegulation(promise: Promise) {
+    override fun getApplicableRegulation(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().applicableRegulation.value)
         } catch (e: DidomiNotReadyException) {
@@ -598,7 +598,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun hideNotice(promise: Promise) {
+    override fun hideNotice(promise: Promise) {
         try {
             Didomi.getInstance().hideNotice()
             promise.resolve(0)
@@ -608,7 +608,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun hidePreferences(promise: Promise) {
+    override fun hidePreferences(promise: Promise) {
         try {
             Didomi.getInstance().hidePreferences()
             promise.resolve(0)
@@ -618,7 +618,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isConsentRequired(promise: Promise) {
+    override fun isConsentRequired(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isConsentRequired)
         } catch (e: DidomiNotReadyException) {
@@ -627,7 +627,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun shouldUserStatusBeCollected(promise: Promise) {
+    override fun shouldUserStatusBeCollected(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().shouldUserStatusBeCollected())
         } catch (e: DidomiNotReadyException) {
@@ -636,7 +636,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isUserConsentStatusPartial(promise: Promise) {
+    override fun isUserConsentStatusPartial(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isUserConsentStatusPartial)
         } catch (e: DidomiNotReadyException) {
@@ -645,7 +645,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isUserStatusPartial(promise: Promise) {
+    override fun isUserStatusPartial(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isUserStatusPartial)
         } catch (e: DidomiNotReadyException) {
@@ -654,7 +654,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isUserLegitimateInterestStatusPartial(promise: Promise) {
+    override fun isUserLegitimateInterestStatusPartial(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isUserLegitimateInterestStatusPartial)
         } catch (e: DidomiNotReadyException) {
@@ -663,7 +663,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isNoticeVisible(promise: Promise) {
+    override fun isNoticeVisible(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isNoticeVisible())
         } catch (e: DidomiNotReadyException) {
@@ -672,7 +672,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isPreferencesVisible(promise: Promise) {
+    override fun isPreferencesVisible(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isPreferencesVisible())
         } catch (e: DidomiNotReadyException) {
@@ -681,35 +681,35 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun isError(promise: Promise) {
+    override fun isError(promise: Promise) {
         promise.resolve(Didomi.getInstance().isError)
     }
 
     @ReactMethod
-    fun isReady(promise: Promise) {
+    override fun isReady(promise: Promise) {
         promise.resolve(Didomi.getInstance().isReady)
     }
 
     @ReactMethod
-    fun clearUser(promise: Promise) {
+    override fun clearUser(promise: Promise) {
         Didomi.getInstance().clearUser()
         promise.resolve(0)
     }
 
     @ReactMethod
-    fun setUser(organizationUserId: String, promise: Promise) {
+    override fun setUser(organizationUserId: String, promise: Promise) {
         Didomi.getInstance().setUser(organizationUserId)
         promise.resolve(0)
     }
 
     @ReactMethod
-    fun setUserAndSetupUI(organizationUserId: String, promise: Promise) {
+    override fun setUserAndSetupUI(organizationUserId: String, promise: Promise) {
         Didomi.getInstance().setUser(organizationUserId, reactContext.currentActivity as? FragmentActivity)
         promise.resolve(0)
     }
 
     @ReactMethod
-    fun setUserWithHashAuth(
+    override fun setUserWithHashAuth(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -730,7 +730,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithHashAuthAndSetupUI(
+    override fun setUserWithHashAuthAndSetupUI(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -752,7 +752,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithHashAuthWithExpiration(
+    override fun setUserWithHashAuthWithExpiration(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -775,7 +775,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithHashAuthWithExpirationAndSetupUI(
+    override fun setUserWithHashAuthWithExpirationAndSetupUI(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -799,7 +799,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithEncryptionAuth(
+    override fun setUserWithEncryptionAuth(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -818,7 +818,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithEncryptionAuthAndSetupUI(
+    override fun setUserWithEncryptionAuthAndSetupUI(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -838,7 +838,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithEncryptionAuthWithExpiration(
+    override fun setUserWithEncryptionAuthWithExpiration(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -859,7 +859,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithEncryptionAuthWithExpirationAndSetupUI(
+    override fun setUserWithEncryptionAuthWithExpirationAndSetupUI(
         organizationUserId: String,
         algorithm: String,
         secretId: String,
@@ -881,7 +881,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithAuthParams(
+    override fun setUserWithAuthParams(
         jsonUserAuthParams: String,
         jsonSynchronizedUsers: String?,
         promise: Promise
@@ -908,7 +908,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithAuthParamsAndSetupUI(
+    override fun setUserWithAuthParamsAndSetupUI(
         jsonUserAuthParams: String,
         jsonSynchronizedUsers: String?,
         promise: Promise
@@ -936,7 +936,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithParameters(
+    override fun setUserWithParameters(
         jsonUserParameters: String,
         promise: Promise
     ) {
@@ -951,7 +951,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserWithParametersAndSetupUI(
+    override fun setUserWithParametersAndSetupUI(
         jsonUserParameters: String,
         promise: Promise
     ) {
@@ -967,7 +967,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun showNotice(promise: Promise) {
+    override fun showNotice(promise: Promise) {
         try {
             runOnUiThread {
                 Didomi.getInstance().showNotice(reactContext.currentActivity as? FragmentActivity)
@@ -980,7 +980,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun forceShowNotice(promise: Promise) {
+    override fun forceShowNotice(promise: Promise) {
         try {
             runOnUiThread {
                 Didomi.getInstance().forceShowNotice(reactContext.currentActivity as? FragmentActivity)
@@ -993,7 +993,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun showPreferences(view: String?, promise: Promise) {
+    override fun showPreferences(view: String?, promise: Promise) {
         try {
             runOnUiThread {
                 view?.also {
@@ -1008,7 +1008,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun reset(promise: Promise) {
+    override fun reset(promise: Promise) {
         try {
             Didomi.getInstance().reset()
             promise.resolve(0)
@@ -1018,7 +1018,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserAgreeToAll(promise: Promise) {
+    override fun setUserAgreeToAll(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().setUserAgreeToAll())
         } catch (e: DidomiNotReadyException) {
@@ -1027,7 +1027,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserDisagreeToAll(promise: Promise) {
+    override fun setUserDisagreeToAll(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().setUserDisagreeToAll())
         } catch (e: DidomiNotReadyException) {
@@ -1036,7 +1036,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setCurrentUserStatus(
+    override fun setCurrentUserStatus(
         currentUserStatusAsString: String,
         promise: Promise
     ) {
@@ -1051,7 +1051,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserStatus(
+    override fun setUserStatus(
         purposesConsentStatus: Boolean,
         purposesLIStatus: Boolean,
         vendorsConsentStatus: Boolean,
@@ -1073,7 +1073,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserConsentStatus(
+    override fun setUserConsentStatus(
         enabledPurposeIds: ReadableArray,
         disabledPurposeIds: ReadableArray,
         enabledVendorIds: ReadableArray,
@@ -1100,7 +1100,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun setUserStatusSets(
+    override fun setUserStatusSets(
         enabledConsentPurposeIds: ReadableArray,
         disabledConsentPurposeIds: ReadableArray,
         enabledLIPurposeIds: ReadableArray,
@@ -1130,7 +1130,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun shouldConsentBeCollected(promise: Promise) {
+    override fun shouldConsentBeCollected(promise: Promise) {
         try {
             @Suppress("DEPRECATION")
             promise.resolve(Didomi.getInstance().shouldConsentBeCollected())
@@ -1140,7 +1140,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun updateSelectedLanguage(languageCode: String, promise: Promise) {
+    override fun updateSelectedLanguage(languageCode: String, promise: Promise) {
         try {
             Didomi.getInstance().updateSelectedLanguage(languageCode)
             promise.resolve(0)
@@ -1151,18 +1151,18 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
 
     @Suppress("UNUSED_PARAMETER")
     @ReactMethod
-    fun addListener(eventName: String) {
+    override fun addListener(eventName: String) {
         // Keep: Required for RN built in Event Emitter Calls.
     }
 
     @Suppress("UNUSED_PARAMETER")
     @ReactMethod
-    fun removeListeners(count: Double) {
+    override fun removeListeners(count: Double) {
         // Keep: Required for RN built in Event Emitter Calls.
     }
 
     @ReactMethod
-    fun listenToVendorStatus(vendorId: String, promise: Promise) {
+    override fun listenToVendorStatus(vendorId: String, promise: Promise) {
         if (!vendorStatusListeners.contains(vendorId)) {
             Didomi.getInstance().addVendorStatusListener(vendorId) { vendorStatus ->
                 val statusAsMap = objectToWritableMap(vendorStatus)
@@ -1174,7 +1174,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun stopListeningToVendorStatus(vendorId: String, promise: Promise) {
+    override fun stopListeningToVendorStatus(vendorId: String, promise: Promise) {
         if (vendorStatusListeners.contains(vendorId)) {
             Didomi.getInstance().removeVendorStatusListener(vendorId)
             vendorStatusListeners.remove(vendorId)
@@ -1183,7 +1183,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun commitCurrentUserStatusTransaction(
+    override fun commitCurrentUserStatusTransaction(
         enabledPurposes: ReadableArray,
         disabledPurposes: ReadableArray,
         enabledVendors: ReadableArray,
@@ -1199,7 +1199,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun syncAcknowledged(callbackIndex: Double, promise: Promise) {
+    override fun syncAcknowledged(callbackIndex: Double, promise: Promise) {
         val index = callbackIndex.toInt()
         val result = syncAcknowledgedCallbacks[index]?.let { it() }
         syncAcknowledgedCallbacks.remove(index)
@@ -1211,7 +1211,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(rea
     }
 
     @ReactMethod
-    fun removeSyncAcknowledgedCallback(callbackIndex: Double, promise: Promise) {
+    override fun removeSyncAcknowledgedCallback(callbackIndex: Double, promise: Promise) {
         syncAcknowledgedCallbacks.remove(callbackIndex.toInt())
         promise.resolve(0)
     }

--- a/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiModule.kt
@@ -24,7 +24,11 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+class DidomiModule(reactContext: ReactApplicationContext) : DidomiModuleSpec(reactContext) {
+
+    companion object {
+        const val NAME = "Didomi"
+    }
 
     val gson = Gson()
 
@@ -247,7 +251,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     private val syncAcknowledgedCallbacks: MutableMap<Int, () -> Boolean> = mutableMapOf()
     private var syncAcknowledgedCallbackIndex = 0
 
-    override fun getName() = "Didomi"
+    override fun getName() = NAME
 
     override fun getConstants(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()
@@ -424,9 +428,9 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
-    fun setLogLevel(level: Int, promise: Promise) {
+    fun setLogLevel(level: Double, promise: Promise) {
         Didomi.getInstance().setLogLevel(
-            when (level) {
+            when (level.toInt()) {
                 0 -> Log.INFO
                 1 -> Log.DEBUG
                 2 -> Log.WARN
@@ -650,6 +654,15 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
+    fun isUserLegitimateInterestStatusPartial(promise: Promise) {
+        try {
+            promise.resolve(Didomi.getInstance().isUserLegitimateInterestStatusPartial)
+        } catch (e: DidomiNotReadyException) {
+            promise.reject(e)
+        }
+    }
+
+    @ReactMethod
     fun isNoticeVisible(promise: Promise) {
         try {
             promise.resolve(Didomi.getInstance().isNoticeVisible())
@@ -745,7 +758,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         secretId: String,
         digest: String,
         salt: String?,
-        expiration: Int,
+        expiration: Double,
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
@@ -768,7 +781,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         secretId: String,
         digest: String,
         salt: String?,
-        expiration: Int,
+        expiration: Double,
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
@@ -830,7 +843,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         algorithm: String,
         secretId: String,
         initializationVector: String,
-        expiration: Int,
+        expiration: Double,
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
@@ -851,7 +864,7 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
         algorithm: String,
         secretId: String,
         initializationVector: String,
-        expiration: Int,
+        expiration: Double,
         promise: Promise
     ) {
         Didomi.getInstance().setUser(
@@ -967,6 +980,19 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
+    fun forceShowNotice(promise: Promise) {
+        try {
+            runOnUiThread {
+                Didomi.getInstance().forceShowNotice(reactContext.currentActivity as? FragmentActivity)
+            }
+            promise.resolve(0)
+        } catch (e: Exception) {
+            Log.e("forceShowNotice", "An error occurred while force-showing the notice", e)
+            promise.reject(e)
+        }
+    }
+
+    @ReactMethod
     fun showPreferences(view: String?, promise: Promise) {
         try {
             runOnUiThread {
@@ -1047,6 +1073,33 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
+    fun setUserConsentStatus(
+        enabledPurposeIds: ReadableArray,
+        disabledPurposeIds: ReadableArray,
+        enabledVendorIds: ReadableArray,
+        disabledVendorIds: ReadableArray,
+        promise: Promise
+    ) {
+        try {
+            @Suppress("DEPRECATION")
+            promise.resolve(
+                Didomi.getInstance().setUserStatus(
+                    enabledPurposeIds.toSet(),
+                    disabledPurposeIds.toSet(),
+                    emptySet(),
+                    emptySet(),
+                    enabledVendorIds.toSet(),
+                    disabledVendorIds.toSet(),
+                    emptySet(),
+                    emptySet()
+                )
+            )
+        } catch (e: DidomiNotReadyException) {
+            promise.reject(e)
+        }
+    }
+
+    @ReactMethod
     fun setUserStatusSets(
         enabledConsentPurposeIds: ReadableArray,
         disabledConsentPurposeIds: ReadableArray,
@@ -1104,12 +1157,12 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
 
     @Suppress("UNUSED_PARAMETER")
     @ReactMethod
-    fun removeListeners(count: Int) {
+    fun removeListeners(count: Double) {
         // Keep: Required for RN built in Event Emitter Calls.
     }
 
     @ReactMethod
-    fun listenToVendorStatus(vendorId: String) {
+    fun listenToVendorStatus(vendorId: String, promise: Promise) {
         if (!vendorStatusListeners.contains(vendorId)) {
             Didomi.getInstance().addVendorStatusListener(vendorId) { vendorStatus ->
                 val statusAsMap = objectToWritableMap(vendorStatus)
@@ -1117,14 +1170,16 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
             }
             vendorStatusListeners.add(vendorId)
         }
+        promise.resolve(0)
     }
 
     @ReactMethod
-    fun stopListeningToVendorStatus(vendorId: String) {
+    fun stopListeningToVendorStatus(vendorId: String, promise: Promise) {
         if (vendorStatusListeners.contains(vendorId)) {
             Didomi.getInstance().removeVendorStatusListener(vendorId)
             vendorStatusListeners.remove(vendorId)
         }
+        promise.resolve(0)
     }
 
     @ReactMethod
@@ -1144,9 +1199,10 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
-    fun syncAcknowledged(callbackIndex: Int, promise: Promise) {
-        val result = syncAcknowledgedCallbacks[callbackIndex]?.let { it() }
-        syncAcknowledgedCallbacks.remove(callbackIndex)
+    fun syncAcknowledged(callbackIndex: Double, promise: Promise) {
+        val index = callbackIndex.toInt()
+        val result = syncAcknowledgedCallbacks[index]?.let { it() }
+        syncAcknowledgedCallbacks.remove(index)
         if (result != null) {
             promise.resolve(result)
         } else {
@@ -1155,8 +1211,8 @@ class DidomiModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
     }
 
     @ReactMethod
-    fun removeSyncAcknowledgedCallback(callbackIndex: Int, promise: Promise) {
-        syncAcknowledgedCallbacks.remove(callbackIndex)
+    fun removeSyncAcknowledgedCallback(callbackIndex: Double, promise: Promise) {
+        syncAcknowledgedCallbacks.remove(callbackIndex.toInt())
         promise.resolve(0)
     }
 

--- a/android/src/main/java/io/didomi/reactnative/DidomiPackage.kt
+++ b/android/src/main/java/io/didomi/reactnative/DidomiPackage.kt
@@ -1,16 +1,27 @@
 package io.didomi.reactnative
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class DidomiPackage : ReactPackage {
-    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(DidomiModule(reactContext))
-    }
+class DidomiPackage : TurboReactPackage() {
 
-    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        return emptyList()
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
+        if (name == DidomiModule.NAME) DidomiModule(reactContext) else null
+
+    override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
+        mapOf(
+            DidomiModule.NAME to ReactModuleInfo(
+                DidomiModule.NAME,
+                DidomiModule.NAME,
+                false, // canOverrideExistingModule
+                false, // needsEagerInit
+                true,  // hasConstants — DidomiModule.getConstants() exposes event registration names
+                false, // isCxxModule
+                BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+            )
+        )
     }
 }

--- a/android/src/newarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
+++ b/android/src/newarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
@@ -1,0 +1,6 @@
+package io.didomi.reactnative
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class DidomiModuleSpec(reactContext: ReactApplicationContext) :
+    NativeDidomiSpec(reactContext)

--- a/android/src/oldarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
+++ b/android/src/oldarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
@@ -1,0 +1,7 @@
+package io.didomi.reactnative
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+
+abstract class DidomiModuleSpec(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext)

--- a/android/src/oldarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
+++ b/android/src/oldarch/java/io/didomi/reactnative/DidomiModuleSpec.kt
@@ -1,7 +1,222 @@
 package io.didomi.reactnative
 
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReadableArray
 
+/**
+ * Old-architecture base class.
+ *
+ * Under the new architecture this class is replaced (via Gradle source-set selection)
+ * by one that extends the codegen-generated `NativeDidomiSpec`. The codegen base declares
+ * all spec methods as `open`, so subclasses must mark them `override`. To keep
+ * `DidomiModule` source identical between architectures, the old-arch variant of
+ * `DidomiModuleSpec` declares the same methods here as `open` stubs that throw
+ * if not overridden — they are always overridden by `DidomiModule`.
+ */
 abstract class DidomiModuleSpec(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext)
+    ReactContextBaseJavaModule(reactContext) {
+
+    private fun stub(): Nothing =
+        throw NotImplementedError("DidomiModuleSpec stub: subclass must override")
+
+    open fun initialize(
+        userAgentName: String,
+        userAgentVersion: String,
+        apiKey: String,
+        localConfigurationPath: String?,
+        remoteConfigurationUrl: String?,
+        providerId: String?,
+        disableDidomiRemoteConfig: Boolean,
+        languageCode: String?,
+        noticeId: String?,
+        androidTvNoticeId: String?,
+        androidTvEnabled: Boolean,
+        countryCode: String?,
+        regionCode: String?,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun initializeWithParameters(
+        userAgentName: String,
+        userAgentVersion: String,
+        jsonParameters: String,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun onReady(promise: Promise): Unit = stub()
+    open fun onError(promise: Promise): Unit = stub()
+    open fun setupUI(promise: Promise): Unit = stub()
+    open fun setLogLevel(level: Double, promise: Promise): Unit = stub()
+    open fun getJavaScriptForWebView(extra: String?, promise: Promise): Unit = stub()
+    open fun getQueryStringForWebView(promise: Promise): Unit = stub()
+    open fun getPurpose(purposeId: String, promise: Promise): Unit = stub()
+    open fun getRequiredPurposes(promise: Promise): Unit = stub()
+    open fun getRequiredPurposeIds(promise: Promise): Unit = stub()
+    open fun getVendor(vendorId: String, promise: Promise): Unit = stub()
+    open fun getTotalVendorCount(promise: Promise): Unit = stub()
+    open fun getIabVendorCount(promise: Promise): Unit = stub()
+    open fun getNonIabVendorCount(promise: Promise): Unit = stub()
+    open fun getRequiredVendors(promise: Promise): Unit = stub()
+    open fun getRequiredVendorIds(promise: Promise): Unit = stub()
+    open fun getText(textKey: String, promise: Promise): Unit = stub()
+    open fun getTranslatedText(key: String, promise: Promise): Unit = stub()
+    open fun getCurrentUserStatus(promise: Promise): Unit = stub()
+    open fun getUserStatus(promise: Promise): Unit = stub()
+    open fun getApplicableRegulation(promise: Promise): Unit = stub()
+    open fun hideNotice(promise: Promise): Unit = stub()
+    open fun hidePreferences(promise: Promise): Unit = stub()
+    open fun isConsentRequired(promise: Promise): Unit = stub()
+    open fun shouldUserStatusBeCollected(promise: Promise): Unit = stub()
+    open fun isUserConsentStatusPartial(promise: Promise): Unit = stub()
+    open fun isUserStatusPartial(promise: Promise): Unit = stub()
+    open fun isUserLegitimateInterestStatusPartial(promise: Promise): Unit = stub()
+    open fun isNoticeVisible(promise: Promise): Unit = stub()
+    open fun isPreferencesVisible(promise: Promise): Unit = stub()
+    open fun isError(promise: Promise): Unit = stub()
+    open fun isReady(promise: Promise): Unit = stub()
+    open fun clearUser(promise: Promise): Unit = stub()
+    open fun setUser(organizationUserId: String, promise: Promise): Unit = stub()
+    open fun setUserAndSetupUI(organizationUserId: String, promise: Promise): Unit = stub()
+
+    open fun setUserWithHashAuth(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        digest: String,
+        salt: String?,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithHashAuthAndSetupUI(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        digest: String,
+        salt: String?,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithHashAuthWithExpiration(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        digest: String,
+        salt: String?,
+        expiration: Double,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithHashAuthWithExpirationAndSetupUI(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        digest: String,
+        salt: String?,
+        expiration: Double,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithEncryptionAuth(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        initializationVector: String,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithEncryptionAuthAndSetupUI(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        initializationVector: String,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithEncryptionAuthWithExpiration(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        initializationVector: String,
+        expiration: Double,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithEncryptionAuthWithExpirationAndSetupUI(
+        organizationUserId: String,
+        algorithm: String,
+        secretId: String,
+        initializationVector: String,
+        expiration: Double,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithAuthParams(
+        jsonUserAuthParams: String,
+        jsonSynchronizedUsers: String?,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithAuthParamsAndSetupUI(
+        jsonUserAuthParams: String,
+        jsonSynchronizedUsers: String?,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserWithParameters(jsonUserParameters: String, promise: Promise): Unit = stub()
+    open fun setUserWithParametersAndSetupUI(jsonUserParameters: String, promise: Promise): Unit = stub()
+    open fun showNotice(promise: Promise): Unit = stub()
+    open fun forceShowNotice(promise: Promise): Unit = stub()
+    open fun showPreferences(view: String?, promise: Promise): Unit = stub()
+    open fun reset(promise: Promise): Unit = stub()
+    open fun setUserAgreeToAll(promise: Promise): Unit = stub()
+    open fun setUserDisagreeToAll(promise: Promise): Unit = stub()
+    open fun setCurrentUserStatus(currentUserStatusAsString: String, promise: Promise): Unit = stub()
+
+    open fun setUserStatus(
+        purposesConsentStatus: Boolean,
+        purposesLIStatus: Boolean,
+        vendorsConsentStatus: Boolean,
+        vendorsLIStatus: Boolean,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserConsentStatus(
+        enabledPurposeIds: ReadableArray,
+        disabledPurposeIds: ReadableArray,
+        enabledVendorIds: ReadableArray,
+        disabledVendorIds: ReadableArray,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun setUserStatusSets(
+        enabledConsentPurposeIds: ReadableArray,
+        disabledConsentPurposeIds: ReadableArray,
+        enabledLIPurposeIds: ReadableArray,
+        disabledLIPurposeIds: ReadableArray,
+        enabledConsentVendorIds: ReadableArray,
+        disabledConsentVendorIds: ReadableArray,
+        enabledLIVendorIds: ReadableArray,
+        disabledLIVendorIds: ReadableArray,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun shouldConsentBeCollected(promise: Promise): Unit = stub()
+    open fun updateSelectedLanguage(languageCode: String, promise: Promise): Unit = stub()
+    open fun addListener(eventName: String): Unit = stub()
+    open fun removeListeners(count: Double): Unit = stub()
+    open fun listenToVendorStatus(vendorId: String, promise: Promise): Unit = stub()
+    open fun stopListeningToVendorStatus(vendorId: String, promise: Promise): Unit = stub()
+
+    open fun commitCurrentUserStatusTransaction(
+        enabledPurposes: ReadableArray,
+        disabledPurposes: ReadableArray,
+        enabledVendors: ReadableArray,
+        disabledVendors: ReadableArray,
+        promise: Promise
+    ): Unit = stub()
+
+    open fun syncAcknowledged(callbackIndex: Double, promise: Promise): Unit = stub()
+    open fun removeSyncAcknowledgedCallback(callbackIndex: Double, promise: Promise): Unit = stub()
+}

--- a/ios/Didomi.m
+++ b/ios/Didomi.m
@@ -50,6 +50,12 @@ RCT_EXTERN_METHOD(shouldUserStatusBeCollected:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(isUserLegitimateInterestStatusPartial:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(isUserConsentStatusPartial:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isError:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(isUserStatusPartial:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/Didomi.m
+++ b/ios/Didomi.m
@@ -179,7 +179,7 @@ RCT_EXTERN_METHOD(getText:(NSString *)key
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(setLogLevel:(int)minLevel
+RCT_EXTERN_METHOD(setLogLevel:(double)minLevel
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
@@ -291,11 +291,11 @@ RCT_EXTERN_METHOD(commitCurrentUserStatusTransaction:(NSArray<NSString *> *)enab
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(syncAcknowledged:(int)callbackIndex
+RCT_EXTERN_METHOD(syncAcknowledged:(double)callbackIndex
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(removeSyncAcknowledgedCallback:(int)callbackIndex
+RCT_EXTERN_METHOD(removeSyncAcknowledgedCallback:(double)callbackIndex
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNDidomi+TurboModule.mm
+++ b/ios/RNDidomi+TurboModule.mm
@@ -1,8 +1,12 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import "RNDidomiSpec/RNDidomiSpec.h"
+
+@interface Didomi : RCTEventEmitter
+@end
 
 @interface Didomi (TurboModule) <NativeDidomiSpec>
 @end

--- a/ios/RNDidomi+TurboModule.mm
+++ b/ios/RNDidomi+TurboModule.mm
@@ -1,0 +1,20 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTBridgeModule.h>
+#import <ReactCommon/RCTTurboModule.h>
+#import "RNDidomiSpec/RNDidomiSpec.h"
+
+@interface Didomi (TurboModule) <NativeDidomiSpec>
+@end
+
+@implementation Didomi (TurboModule)
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeDidomiSpecJSI>(params);
+}
+
+@end
+
+#endif

--- a/ios/RNDidomi.swift
+++ b/ios/RNDidomi.swift
@@ -358,10 +358,10 @@ class RNDidomi: RCTEventEmitter {
     }
 
     @objc(setLogLevel:resolve:reject:)
-    dynamic func setLogLevel(minLevel: UInt8, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
+    dynamic func setLogLevel(minLevel: Double, resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
         var level: UInt8
-        
-        switch minLevel {
+
+        switch Int(minLevel) {
         case 0:
             level = 1
         case 1:
@@ -373,7 +373,7 @@ class RNDidomi: RCTEventEmitter {
         default:
             level = 17
         }
-        
+
         Didomi.shared.setLogLevel(minLevel: level)
         resolve(0)
     }
@@ -661,25 +661,26 @@ class RNDidomi: RCTEventEmitter {
     
     @objc(syncAcknowledged:resolve:reject:)
     dynamic func syncAcknowledged(
-       callbackIndex: Int,
+       callbackIndex: Double,
        resolve:RCTPromiseResolveBlock,
        reject:RCTPromiseRejectBlock
     ) {
-        if let callback = syncAcknowledgedCallbacks[callbackIndex] {
-            syncAcknowledgedCallbacks.removeValue(forKey: callbackIndex)
+        let key = Int(callbackIndex)
+        if let callback = syncAcknowledgedCallbacks[key] {
+            syncAcknowledgedCallbacks.removeValue(forKey: key)
             resolve(callback())
         } else {
             reject("not_found", "SyncAcknowledged: Native callback not found. The method can be called only once.", NSError.init(domain: "Didomi", code: 404))
         }
     }
-    
+
     @objc(removeSyncAcknowledgedCallback:resolve:reject:)
     dynamic func removeSyncAcknowledgedCallback(
-       callbackIndex: Int,
+       callbackIndex: Double,
        resolve:RCTPromiseResolveBlock,
        reject:RCTPromiseRejectBlock
     ) {
-        syncAcknowledgedCallbacks.removeValue(forKey: callbackIndex)
+        syncAcknowledgedCallbacks.removeValue(forKey: Int(callbackIndex))
         resolve(0)
     }
 }

--- a/ios/RNDidomi.swift
+++ b/ios/RNDidomi.swift
@@ -121,6 +121,11 @@ class RNDidomi: RCTEventEmitter {
         resolve(Didomi.shared.isUserConsentStatusPartial())
     }
 
+    @objc(isError:reject:)
+    func isError(resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
+        resolve(Didomi.shared.isError())
+    }
+
     @objc(isUserStatusPartial:reject:)
     func isUserStatusPartial(resolve:RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
         resolve(Didomi.shared.isUserStatusPartial())

--- a/package.json
+++ b/package.json
@@ -98,5 +98,14 @@
     "plugins": [
       "./plugin/withDidomi.js"
     ]
+  },
+  "codegenConfig": {
+    "name": "RNDidomiSpec",
+    "type": "modules",
+    "jsSrcsDir": "src/specs",
+    "android": {
+      "javaPackageName": "io.didomi.reactnative"
+    },
+    "includesGeneratedCode": false
   }
 }

--- a/react-native-didomi.podspec
+++ b/react-native-didomi.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "Didomi-XCFramework", "2.42.0"
+  s.dependency "Didomi-XCFramework", "2.43.0"
 
   install_modules_dependencies(s)
 end

--- a/react-native-didomi.podspec
+++ b/react-native-didomi.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "React-Core"
   s.dependency "Didomi-XCFramework", "2.42.0"
+
+  install_modules_dependencies(s)
 end

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        libraryName: 'RNDidomiSpec',
+        cmakeListsPath: 'build/generated/source/codegen/jni/CMakeLists.txt',
+      },
+    },
+  },
+};

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -36,5 +36,20 @@ target 'sample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Xcode 26 / Clang 21 enforces consteval more strictly, breaking fmt v9's FMT_STRING macro.
+    # fmt/base.h gates FMT_USE_CONSTEVAL on Apple clang < 14; widen that to all Apple clang versions.
+    fmt_base = File.join(__dir__, 'Pods/fmt/include/fmt/base.h')
+    if File.exist?(fmt_base)
+      contents = File.read(fmt_base)
+      patched = contents.sub(
+        '#elif defined(__apple_build_version__) && __apple_build_version__ < 14000029L',
+        '#elif defined(__apple_build_version__)'
+      )
+      if patched != contents
+        File.chmod(0644, fmt_base)
+        File.write(fmt_base, patched)
+      end
+    end
   end
 end

--- a/src/Didomi.ts
+++ b/src/Didomi.ts
@@ -1,10 +1,10 @@
-import { NativeModules } from 'react-native';
+import NativeDidomi from './specs/NativeDidomi';
 import { DidomiListener } from './DidomiListener';
 import { DidomiEventType, Purpose, Vendor, UserStatus, CurrentUserStatus, VendorStatus, UserAuthParams, DidomiInitializeParameters, DidomiUserParameters, UserAuthWithEncryptionParams, UserAuthWithHashParams, DidomiMultiUserParameters } from './DidomiTypes';
 import { DIDOMI_USER_AGENT_NAME, DIDOMI_VERSION } from './Constants';
 import { CurrentUserStatusTransaction, createCurrentUserStatusTransaction } from './CurrentUserStatusTransaction';
 
-const { Didomi: RNDidomi } = NativeModules;
+const RNDidomi = NativeDidomi as any;
 
 export const Didomi = {
   /**

--- a/src/DidomiListener.ts
+++ b/src/DidomiListener.ts
@@ -1,7 +1,8 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeEventEmitter } from 'react-native';
+import NativeDidomi from './specs/NativeDidomi';
 import { DidomiEventType, VendorStatus } from './DidomiTypes';
 
-const { Didomi: RNDidomi } = NativeModules;
+const RNDidomi = NativeDidomi as any;
 
 enum InternalEventType {
   READY_CALLBACK = 'on_ready_callback',

--- a/src/__tests__/DidomiListener.test.ts
+++ b/src/__tests__/DidomiListener.test.ts
@@ -1,8 +1,19 @@
-import { DidomiListener } from '../DidomiListener';
-import { DidomiEventType } from '../DidomiTypes';
-
 // Mocked NativeEventEmitter
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+
+// Mock the spec module so TurboModuleRegistry.getEnforcing doesn't throw in unit tests
+jest.mock('../specs/NativeDidomi', () => ({
+  __esModule: true,
+  default: {
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+    syncAcknowledged: jest.fn(),
+    removeSyncAcknowledgedCallback: jest.fn(),
+  },
+}));
+
+import { DidomiListener } from '../DidomiListener';
+import { DidomiEventType } from '../DidomiTypes';
 
 describe('test add listener', () => {
   it('add listener', () => {

--- a/src/specs/NativeDidomi.ts
+++ b/src/specs/NativeDidomi.ts
@@ -1,0 +1,187 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  initialize(
+    userAgentName: string,
+    userAgentVersion: string,
+    apiKey: string,
+    localConfigurationPath: string | null,
+    remoteConfigurationURL: string | null,
+    providerId: string | null,
+    disableDidomiRemoteConfig: boolean,
+    languageCode: string | null,
+    noticeId: string | null,
+    androidTvNoticeId: string | null,
+    androidTvEnabled: boolean,
+    countryCode: string | null,
+    regionCode: string | null
+  ): Promise<void>;
+
+  initializeWithParameters(
+    userAgentName: string,
+    userAgentVersion: string,
+    parameters: string
+  ): Promise<void>;
+
+  onReady(): Promise<void>;
+  onError(): Promise<void>;
+  isReady(): Promise<boolean>;
+  isError(): Promise<boolean>;
+  reset(): Promise<void>;
+  clearUser(): Promise<void>;
+
+  setupUI(): Promise<void>;
+  forceShowNotice(): Promise<void>;
+  showNotice(): Promise<void>;
+  hideNotice(): Promise<void>;
+  isNoticeVisible(): Promise<boolean>;
+  showPreferences(view: string | null): Promise<void>;
+  hidePreferences(): Promise<void>;
+  isPreferencesVisible(): Promise<boolean>;
+
+  isConsentRequired(): Promise<boolean>;
+  shouldUserStatusBeCollected(): Promise<boolean>;
+  shouldConsentBeCollected(): Promise<boolean>;
+  isUserConsentStatusPartial(): Promise<boolean>;
+  isUserStatusPartial(): Promise<boolean>;
+  isUserLegitimateInterestStatusPartial(): Promise<boolean>;
+
+  getCurrentUserStatus(): Promise<Object>;
+  setCurrentUserStatus(currentUserStatusAsString: string): Promise<boolean>;
+  getUserStatus(): Promise<Object>;
+  setUserStatus(
+    purposesConsentStatus: boolean,
+    purposesLIStatus: boolean,
+    vendorsConsentStatus: boolean,
+    vendorsLIStatus: boolean
+  ): Promise<boolean>;
+  setUserStatusSets(
+    enabledConsentPurposeIds: Array<string>,
+    disabledConsentPurposeIds: Array<string>,
+    enabledLIPurposeIds: Array<string>,
+    disabledLIPurposeIds: Array<string>,
+    enabledConsentVendorIds: Array<string>,
+    disabledConsentVendorIds: Array<string>,
+    enabledLIVendorIds: Array<string>,
+    disabledLIVendorIds: Array<string>
+  ): Promise<boolean>;
+  setUserConsentStatus(
+    enabledPurposeIds: Array<string>,
+    disabledPurposeIds: Array<string>,
+    enabledVendorIds: Array<string>,
+    disabledVendorIds: Array<string>
+  ): Promise<boolean>;
+  setUserAgreeToAll(): Promise<boolean>;
+  setUserDisagreeToAll(): Promise<boolean>;
+
+  getApplicableRegulation(): Promise<string>;
+  getPurpose(purposeId: string): Promise<Object>;
+  getRequiredPurposes(): Promise<Object>;
+  getRequiredPurposeIds(): Promise<Array<string>>;
+  getVendor(vendorId: string): Promise<Object>;
+  getRequiredVendors(): Promise<Object>;
+  getRequiredVendorIds(): Promise<Array<string>>;
+  getTotalVendorCount(): Promise<number>;
+  getIabVendorCount(): Promise<number>;
+  getNonIabVendorCount(): Promise<number>;
+
+  getText(key: string): Promise<Object>;
+  getTranslatedText(key: string): Promise<string>;
+  getJavaScriptForWebView(extra: string | null): Promise<string>;
+  getQueryStringForWebView(): Promise<string>;
+  updateSelectedLanguage(languageCode: string): Promise<void>;
+
+  setLogLevel(level: number): Promise<void>;
+
+  setUser(id: string): Promise<void>;
+  setUserAndSetupUI(id: string): Promise<void>;
+
+  setUserWithHashAuth(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    digest: string,
+    salt: string | null
+  ): Promise<void>;
+  setUserWithHashAuthAndSetupUI(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    digest: string,
+    salt: string | null
+  ): Promise<void>;
+  setUserWithHashAuthWithExpiration(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    digest: string,
+    salt: string | null,
+    expiration: number
+  ): Promise<void>;
+  setUserWithHashAuthWithExpirationAndSetupUI(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    digest: string,
+    salt: string | null,
+    expiration: number
+  ): Promise<void>;
+
+  setUserWithEncryptionAuth(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    initializationVector: string
+  ): Promise<void>;
+  setUserWithEncryptionAuthAndSetupUI(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    initializationVector: string
+  ): Promise<void>;
+  setUserWithEncryptionAuthWithExpiration(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    initializationVector: string,
+    expiration: number
+  ): Promise<void>;
+  setUserWithEncryptionAuthWithExpirationAndSetupUI(
+    id: string,
+    algorithm: string,
+    secretId: string,
+    initializationVector: string,
+    expiration: number
+  ): Promise<void>;
+
+  setUserWithAuthParams(
+    jsonUserAuthParams: string,
+    jsonSynchronizedUsers: string | null
+  ): Promise<void>;
+  setUserWithAuthParamsAndSetupUI(
+    jsonUserAuthParams: string,
+    jsonSynchronizedUsers: string | null
+  ): Promise<void>;
+
+  setUserWithParameters(jsonParameters: string): Promise<void>;
+  setUserWithParametersAndSetupUI(jsonParameters: string): Promise<void>;
+
+  listenToVendorStatus(vendorId: string): Promise<void>;
+  stopListeningToVendorStatus(vendorId: string): Promise<void>;
+
+  commitCurrentUserStatusTransaction(
+    enabledPurposes: Array<string>,
+    disabledPurposes: Array<string>,
+    enabledVendors: Array<string>,
+    disabledVendors: Array<string>
+  ): Promise<boolean>;
+
+  syncAcknowledged(callbackIndex: number): Promise<boolean>;
+  removeSyncAcknowledgedCallback(callbackIndex: number): Promise<void>;
+
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('Didomi');

--- a/test/ios/Podfile
+++ b/test/ios/Podfile
@@ -36,5 +36,20 @@ target 'Didomi' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Xcode 26 / Clang 21 enforces consteval more strictly, breaking fmt v9's FMT_STRING macro.
+    # fmt/base.h gates FMT_USE_CONSTEVAL on Apple clang < 14; widen that to all Apple clang versions.
+    fmt_base = File.join(__dir__, 'Pods/fmt/include/fmt/base.h')
+    if File.exist?(fmt_base)
+      contents = File.read(fmt_base)
+      patched = contents.sub(
+        '#elif defined(__apple_build_version__) && __apple_build_version__ < 14000029L',
+        '#elif defined(__apple_build_version__)'
+      )
+      if patched != contents
+        File.chmod(0644, fmt_base)
+        File.write(fmt_base, patched)
+      end
+    end
   end
 end


### PR DESCRIPTION
Migrating the Didomi RN SDK to TurboModule with backward compat; spec, codegen config, podspec, Android build/package/module, iOS shim, and JS imports are all done and tsc/jest/bob build pass. Next: run pod install and a Gradle build in /test to confirm codegen wires up correctly.

###  JS / TypeScript
  - Added `src/specs/NativeDidomi.ts` — codegen TurboModule spec covering 65 methods, with the JSON-string-as-string contract preserved so call sites don't change.
  - Switched `src/Didomi.ts` and `src/DidomiListener.ts` to import the spec via `TurboModuleRegistry.getEnforcing<Spec>('Didomi')`. The interop fallback handles old-arch consumers transparently.
  - Added Jest mock for the spec in `DidomiListener.test.ts` so unit tests don't try to resolve the native module.

###   Package config
  - Added `codegenConfig` block to `package.json` (name `RNDidomiSpec`, `jsSrcsDir src/specs`, `javaPackageName io.didomi.reactnative`).

  ### iOS
  - Created `ios/RNDidomi+TurboModule.mm` — ObjC++ category on Didomi that conforms to `NativeDidomiSpec` and vends a `NativeDidomiSpecJSI`, guarded by `#ifdef RCT_NEW_ARCH_ENABLED`.
  - `react-native-didomi.podspec` now uses install_modules_dependencies(s) instead of a manual React-Core dep — picks up codegen, TurboModule core, and Folly automatically.
  - Added isError to `RNDidomi.swift` and registered `isError` + `isUserConsentStatusPartial` in `ios/Didomi.m` (the iOS side was missing these — Android had them already).

###   Android
  - `android/build.gradle`: applied com.facebook.react plugin, added react { jsRootDir, libraryName, codegenJavaPackageName }, `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`, and a sourceSets split between src/oldarch and src/newarch.
  - `DidomiPackage.kt`: switched from `ReactPackage` to `TurboReactPackage` with a `ReactModuleInfoProvider` driven by `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`.
  - Created `DidomiModuleSpec.kt` in both oldarch (extends ReactContextBaseJavaModule) and newarch (extends generated NativeDidomiSpec). DidomiModule now extends DidomiModuleSpec.
  - Widened Int → Double on `setLogLevel`, `syncAcknowledged`, `removeSyncAcknowledgedCallback`, both `*WithExpiration` setters, and `removeListeners` to match codegen's number → Double mapping; narrowed inside method bodies.
  - Added `forceShowNotice`, `isUserLegitimateInterestStatusPartial`, and `setUserConsentStatus` on Android (missing from the original module).
  - Added NAME companion constant and made `listenToVendorStatus`/`stopListeningToVendorStatus` return Promise.